### PR TITLE
Modal controller presenting animation fix

### DIFF
--- a/Pod/Classes/UI/RXModalViewController.m
+++ b/Pod/Classes/UI/RXModalViewController.m
@@ -279,7 +279,7 @@
             CGContextTranslateCTM(context, -imageSize.width, -imageSize.height);
         }
         if ([window respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
-            [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:YES];
+            [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:NO];
         } else {
             [window.layer renderInContext:context];
         }


### PR DESCRIPTION
Fixes bug with presenting modal controller, when run on iPhone 6/6+ in scaled mode (not native resolution, but the one that is used for legacy apps). Calling drawing in context after updates caused scaling screenshot up and then immediately hiding behind other subviews - that looks like noticeable 'jumping' of animation