### PR TITLE
Proper ISO8601 date formatter

### DIFF
--- a/Rover/Common.swift
+++ b/Rover/Common.swift
@@ -43,6 +43,6 @@ var rvDateFormatter: DateFormatter {
     let dateFormatter = DateFormatter()
     let enUSPOSIXLocale = Locale(identifier: "en_US_POSIX")
     dateFormatter.locale = enUSPOSIXLocale
-    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZ"
+    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
     return dateFormatter
 }


### PR DESCRIPTION
`ZZZZ` is mapped to Localized GMT but server expects ISO8601 timestamps which uses the format `ZZZZZ`
Reference http://www.unicode.org/reports/tr35/tr35-25.html#Date_Format_Patterns
