### PR TITLE
Identify customer

### DIFF
--- a/Rover.xcodeproj/project.pbxproj
+++ b/Rover.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DB2BA91D1DF5D0EB00C18878 /* Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2BA91C1DF5D0EB00C18878 /* Traits.swift */; };
+		DB2BA9251DF5E38200C18878 /* TraitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2BA9241DF5E38200C18878 /* TraitsTests.swift */; };
+		DB2BA9271DF5E38200C18878 /* Rover.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBD0A7BB1D9D707A00A091D7 /* Rover.framework */; };
+		DB2BA9301DF60CDC00C18878 /* RoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2BA92F1DF60CDC00C18878 /* RoverTests.swift */; };
 		DBD0A7C01D9D707A00A091D7 /* Rover.h in Headers */ = {isa = PBXBuildFile; fileRef = DBD0A7BE1D9D707A00A091D7 /* Rover.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBD0A7D41D9D719500A091D7 /* BluetoothStatusOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD0A7CB1D9D719500A091D7 /* BluetoothStatusOperation.swift */; };
 		DBD0A7D51D9D719500A091D7 /* EventOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD0A7CC1D9D719500A091D7 /* EventOperation.swift */; };
@@ -49,7 +53,22 @@
 		DBD0A8181D9D721E00A091D7 /* WebBlockViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD0A80C1D9D721E00A091D7 /* WebBlockViewCell.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		DB2BA9281DF5E38200C18878 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DBD0A7B21D9D707A00A091D7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DBD0A7BA1D9D707A00A091D7;
+			remoteInfo = Rover;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		DB2BA91C1DF5D0EB00C18878 /* Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Traits.swift; sourceTree = "<group>"; };
+		DB2BA9221DF5E38200C18878 /* RoverTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RoverTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DB2BA9241DF5E38200C18878 /* TraitsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraitsTests.swift; sourceTree = "<group>"; };
+		DB2BA9261DF5E38200C18878 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DB2BA92F1DF60CDC00C18878 /* RoverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoverTests.swift; sourceTree = "<group>"; };
 		DBD0A7BB1D9D707A00A091D7 /* Rover.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rover.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBD0A7BE1D9D707A00A091D7 /* Rover.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rover.h; sourceTree = "<group>"; };
 		DBD0A7BF1D9D707A00A091D7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -95,6 +114,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		DB2BA91F1DF5E38200C18878 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DB2BA9271DF5E38200C18878 /* Rover.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DBD0A7B71D9D707A00A091D7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -105,10 +132,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		DB2BA9231DF5E38200C18878 /* RoverTests */ = {
+			isa = PBXGroup;
+			children = (
+				DB2BA92F1DF60CDC00C18878 /* RoverTests.swift */,
+				DB2BA9241DF5E38200C18878 /* TraitsTests.swift */,
+				DB2BA9261DF5E38200C18878 /* Info.plist */,
+			);
+			path = RoverTests;
+			sourceTree = "<group>";
+		};
 		DBD0A7B11D9D707A00A091D7 = {
 			isa = PBXGroup;
 			children = (
 				DBD0A7BD1D9D707A00A091D7 /* Rover */,
+				DB2BA9231DF5E38200C18878 /* RoverTests */,
 				DBD0A7BC1D9D707A00A091D7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -117,6 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				DBD0A7BB1D9D707A00A091D7 /* Rover.framework */,
+				DB2BA9221DF5E38200C18878 /* RoverTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -176,6 +215,7 @@
 				DBD0A7ED1D9D720B00A091D7 /* Place.swift */,
 				DBD0A7EE1D9D720B00A091D7 /* Row.swift */,
 				DBD0A7EF1D9D720B00A091D7 /* Screen.swift */,
+				DB2BA91C1DF5D0EB00C18878 /* Traits.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -224,6 +264,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		DB2BA9211DF5E38200C18878 /* RoverTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DB2BA92C1DF5E38200C18878 /* Build configuration list for PBXNativeTarget "RoverTests" */;
+			buildPhases = (
+				DB2BA91E1DF5E38200C18878 /* Sources */,
+				DB2BA91F1DF5E38200C18878 /* Frameworks */,
+				DB2BA9201DF5E38200C18878 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DB2BA9291DF5E38200C18878 /* PBXTargetDependency */,
+			);
+			name = RoverTests;
+			productName = RoverTests;
+			productReference = DB2BA9221DF5E38200C18878 /* RoverTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		DBD0A7BA1D9D707A00A091D7 /* Rover */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DBD0A7C31D9D707A00A091D7 /* Build configuration list for PBXNativeTarget "Rover" */;
@@ -248,9 +306,14 @@
 		DBD0A7B21D9D707A00A091D7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0810;
 				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = "Sean Rucker";
 				TargetAttributes = {
+					DB2BA9211DF5E38200C18878 = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Automatic;
+					};
 					DBD0A7BA1D9D707A00A091D7 = {
 						CreatedOnToolsVersion = 8.0;
 						DevelopmentTeam = WDEZX8QD47;
@@ -272,11 +335,19 @@
 			projectRoot = "";
 			targets = (
 				DBD0A7BA1D9D707A00A091D7 /* Rover */,
+				DB2BA9211DF5E38200C18878 /* RoverTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		DB2BA9201DF5E38200C18878 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DBD0A7B91D9D707A00A091D7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -287,6 +358,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		DB2BA91E1DF5E38200C18878 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DB2BA9301DF60CDC00C18878 /* RoverTests.swift in Sources */,
+				DB2BA9251DF5E38200C18878 /* TraitsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DBD0A7B61D9D707A00A091D7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -304,6 +384,7 @@
 				DBD0A80D1D9D721E00A091D7 /* AssetCache.swift in Sources */,
 				DBD0A7FE1D9D721300A091D7 /* MappingOperation.swift in Sources */,
 				DBD0A7F91D9D720B00A091D7 /* Row.swift in Sources */,
+				DB2BA91D1DF5D0EB00C18878 /* Traits.swift in Sources */,
 				DBD0A7D61D9D719500A091D7 /* LocationAuthorizationOperation.swift in Sources */,
 				DBD0A7D81D9D719500A091D7 /* Mappables.swift in Sources */,
 				DBD0A8111D9D721E00A091D7 /* ButtonBlockViewCell.swift in Sources */,
@@ -334,7 +415,39 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		DB2BA9291DF5E38200C18878 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DBD0A7BA1D9D707A00A091D7 /* Rover */;
+			targetProxy = DB2BA9281DF5E38200C18878 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		DB2BA92A1DF5E38200C18878 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = RoverTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = io.rover.RoverTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		DB2BA92B1DF5E38200C18878 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = RoverTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = io.rover.RoverTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
 		DBD0A7C11D9D707A00A091D7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -482,6 +595,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		DB2BA92C1DF5E38200C18878 /* Build configuration list for PBXNativeTarget "RoverTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DB2BA92A1DF5E38200C18878 /* Debug */,
+				DB2BA92B1DF5E38200C18878 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		DBD0A7B51D9D707A00A091D7 /* Build configuration list for PBXProject "Rover" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Rover/Customer.swift
+++ b/Rover/Customer.swift
@@ -63,7 +63,7 @@ open class Customer : NSObject, NSCoding {
     }
     
     open func encode(with aCoder: NSCoder) {
-        aCoder.encode(firstName, forKey: "firstname")
+        aCoder.encode(firstName, forKey: "firstName")
         aCoder.encode(lastName, forKey: "lastName")
         aCoder.encode(email, forKey: "email")
         aCoder.encode(phone, forKey: "phone")

--- a/Rover/Rover.swift
+++ b/Rover/Rover.swift
@@ -49,6 +49,70 @@ open class Rover : NSObject {
     
     open static let customer = Customer.sharedCustomer
     
+    open static func identify(traits: Traits) {
+        if let identifier = traits.identifier {
+            customer.identifier = identifier as? String
+        }
+        
+        if let firstName = traits.firstName {
+            customer.firstName = firstName as? String
+        }
+        
+        if let lastName = traits.lastName {
+            customer.lastName = lastName as? String
+        }
+        
+        if let email = traits.email {
+            customer.email = email as? String
+        }
+        
+        if let phoneNumber = traits.phoneNumber {
+            customer.phone = phoneNumber as? String
+        }
+        
+        if let tags = traits.tags {
+            customer.tags = tags
+        } else {
+            if let tagsToAdd = traits.tagsToAdd {
+                customer.tags?.append(contentsOf: tagsToAdd)
+            }
+            
+            if let tagsToRemove = traits.tagsToRemove {
+                customer.tags = customer.tags?.filter { !tagsToRemove.contains($0) }
+            }
+        }
+        
+        if let gender = traits.gender {
+            customer.gender = gender as? String
+        }
+        
+        if let age = traits.age {
+            customer.age = age as? Int
+        }
+        
+        if let customValues = traits.customValues {
+            customer.traits = customValues
+        }
+        
+        customer.save()
+        sharedInstance?.sendEvent(.deviceUpdate(date: Date()))
+    }
+    
+    open static func clearCustomer() {
+        customer.identifier = nil
+        customer.firstName = nil
+        customer.lastName = nil
+        customer.email = nil
+        customer.phone = nil
+        customer.tags = nil
+        customer.gender = nil
+        customer.age = nil
+        customer.traits = [String: Any]()
+
+        customer.save()
+        sharedInstance?.sendEvent(.deviceUpdate(date: Date()))
+    }
+    
     open static var isMonitoring: Bool {
         return sharedInstance?.locationManager?.isMonitoring ?? false
     }

--- a/Rover/Rover.swift
+++ b/Rover/Rover.swift
@@ -91,7 +91,10 @@ open class Rover : NSObject {
         }
         
         if let customValues = traits.customValues {
-            customer.traits = customValues
+            customer.traits = [String: Any]()
+            for (key, value) in customValues.filter({ !($0.1 is NSNull) }) {
+                customer.traits[key] = value
+            }
         }
         
         customer.save()

--- a/Rover/Serializables.swift
+++ b/Rover/Serializables.swift
@@ -262,7 +262,7 @@ extension Customer : Serializable {
         let tags: Any = self.tags ?? NSNull()
         let email: Any = self.email ?? NSNull()
         
-        return [
+        var json = [
             "first-name": firstName,
             "last-name": lastName,
             "email": email,
@@ -272,6 +272,12 @@ extension Customer : Serializable {
             "age": age,
             "tags": tags
         ]
+        
+        if let traits = self.traits as? [String: Any] {
+            json["traits"] = traits
+        }
+        
+        return json
     }
 }
 

--- a/Rover/Traits.swift
+++ b/Rover/Traits.swift
@@ -1,0 +1,231 @@
+//
+//  Traits.swift
+//  Rover
+//
+//  Created by Sean Rucker on 2016-12-05.
+//  Copyright © 2016 Sean Rucker. All rights reserved.
+//
+
+import Foundation
+
+public struct Traits {
+    
+    static let identifierKey = "identifier"
+    static let firstNameKey = "first-name"
+    static let lastNameKey = "last-name"
+    static let genderKey = "gender"
+    static let ageKey = "age"
+    static let emailKey = "email"
+    static let phoneNumberKey = "phone-number"
+    static let tagsKey = "tags"
+    static let tagsToAddKey = "tagsToAdd"
+    static let tagsToRemoveKey = "tagsToRemove"
+    
+    static let supportedKeys = Set(arrayLiteral: Traits.identifierKey, Traits.firstNameKey, Traits.lastNameKey, Traits.genderKey, Traits.ageKey, Traits.emailKey, Traits.phoneNumberKey, Traits.tagsKey, Traits.tagsToAddKey, Traits.tagsToRemoveKey)
+    
+    public enum Gender: String {
+        case male, female
+    }
+    
+    var valueMap = [String: Any]()
+    
+    var identifier: Any? {
+        return valueMap[Traits.identifierKey]
+    }
+    
+    var firstName: Any? {
+        return valueMap[Traits.firstNameKey]
+    }
+    
+    var lastName: Any? {
+        return valueMap[Traits.lastNameKey]
+    }
+    
+    var email: Any? {
+        return valueMap[Traits.emailKey]
+    }
+    
+    var phoneNumber: Any? {
+        return valueMap[Traits.phoneNumberKey]
+    }
+    
+    var gender: Any? {
+        return valueMap[Traits.genderKey]
+    }
+    
+    var age: Any? {
+        return valueMap[Traits.ageKey]
+    }
+    
+    var tags: [String]? {
+        return valueMap[Traits.tagsKey] as? [String]
+    }
+    
+    var tagsToAdd: [String]? {
+        return valueMap[Traits.tagsToAddKey] as? [String]
+    }
+    
+    var tagsToRemove: [String]? {
+        return valueMap[Traits.tagsToRemoveKey] as? [String]
+    }
+    
+    var customValues: [String: Any]? {
+        let customValues = self.valueMap.filter { !Traits.supportedKeys.contains($0.0) }
+        
+        guard !customValues.isEmpty else {
+            return nil
+        }
+        
+        var valueMap = [String: Any]()
+        
+        for (key, value) in customValues {
+            valueMap[key] = value
+        }
+        
+        return valueMap
+    }
+    
+    public mutating func set(identifier: String) {
+        valueMap[Traits.identifierKey] = identifier
+    }
+    
+    public mutating func removeIdentifier() {
+        valueMap[Traits.identifierKey] = NSNull()
+    }
+    
+    public mutating func set(firstName: String) {
+        valueMap[Traits.firstNameKey] = firstName
+    }
+    
+    public mutating func removeFirstName() {
+        valueMap[Traits.firstNameKey] = NSNull()
+    }
+    
+    public mutating func set(lastName: String) {
+        valueMap[Traits.lastNameKey] = lastName
+    }
+    
+    public mutating func removeLastName() {
+        valueMap[Traits.lastNameKey] = NSNull()
+    }
+    
+    public mutating func set(email: String) {
+        valueMap[Traits.emailKey] = email
+    }
+    
+    public mutating func removeEmail() {
+        valueMap[Traits.emailKey] = NSNull()
+    }
+    
+    public mutating func set(phoneNumber: String) {
+        valueMap[Traits.phoneNumberKey] = phoneNumber
+    }
+    
+    public mutating func removePhoneNumber() {
+        valueMap[Traits.phoneNumberKey] = NSNull()
+    }
+    
+    public mutating func set(gender: Gender) {
+        valueMap[Traits.genderKey] = gender.rawValue
+    }
+    
+    public mutating func removeGender() {
+        valueMap[Traits.genderKey] = NSNull()
+    }
+    
+    public mutating func set(age: Int) {
+        valueMap[Traits.ageKey] = age
+    }
+    
+    public mutating func removeAge() {
+        valueMap[Traits.ageKey] = NSNull()
+    }
+    
+    public mutating func set(tags: [String]) {
+        valueMap[Traits.tagsKey] = tags
+    }
+    
+    public mutating func add(tag: String) {
+        var tags = valueMap[Traits.tagsToAddKey] as? [String] ?? [String]()
+        tags.append(tag)
+        valueMap[Traits.tagsToAddKey] = tags
+    }
+    
+    public mutating func remove(tag: String) {
+        var tags = valueMap[Traits.tagsToRemoveKey] as? [String] ?? [String]()
+        tags.append(tag)
+        valueMap[Traits.tagsToRemoveKey] = tags
+    }
+    
+    public mutating func set(customValue: Any, forKey key: String) {
+        valueMap[key] = customValue
+    }
+    
+    public mutating func removeCustomValue(forKey key: String) {
+        valueMap[key] = NSNull()
+    }
+    
+    public init() { }
+}
+
+extension Traits: CustomStringConvertible {
+    
+    public var description: String {
+        return String(describing: valueMap)
+    }
+}
+
+extension Traits: ExpressibleByDictionaryLiteral {
+    
+    public typealias Key = String
+    public typealias Value = Any
+    
+    public init(dictionaryLiteral elements: (Traits.Key, Traits.Value)...) {
+        for (key, value) in elements {
+            switch key {
+            case Traits.identifierKey, Traits.firstNameKey, Traits.lastNameKey, Traits.emailKey, Traits.phoneNumberKey:
+                valueMap[key] = value as? String
+            case Traits.genderKey:
+                if let string = value as? String, let gender = Gender(rawValue: string) {
+                    valueMap[key] = gender.rawValue
+                }
+            case Traits.ageKey:
+                valueMap[key] = value as? Int
+            case Traits.tagsKey, Traits.tagsToAddKey, Traits.tagsToRemoveKey:
+                valueMap[key] = value as? [String]
+            default:
+                valueMap[key] = value
+            }
+        }
+    }
+}
+
+extension Traits: Sequence {
+    
+    public typealias Iterator = DictionaryIterator<String, Any>
+    
+    public func makeIterator() -> Iterator {
+        return valueMap.makeIterator()
+    }
+}
+
+extension Traits: Collection {
+    
+    public typealias Index = DictionaryIndex<String, Any>
+    
+    public var startIndex: Index {
+        return valueMap.startIndex
+    }
+    
+    public var endIndex: Index {
+        return valueMap.endIndex
+    }
+    
+    public subscript (position: Index) -> Iterator.Element {
+        return valueMap[position]
+    }
+    
+    public func index(after i: Index) -> Index {
+        return valueMap.index(after: i)
+    }
+}

--- a/RoverTests/Info.plist
+++ b/RoverTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/RoverTests/RoverTests.swift
+++ b/RoverTests/RoverTests.swift
@@ -1,0 +1,85 @@
+//
+//  RoverTests.swift
+//  Rover
+//
+//  Created by Sean Rucker on 2016-12-05.
+//  Copyright © 2016 Sean Rucker. All rights reserved.
+//
+
+import XCTest
+@testable import Rover
+
+class RoverTests: XCTestCase {
+    
+    func identifyAsMarie() {
+        var traits = Traits()
+        traits.set(identifier: "marieavgeropoulos")
+        traits.set(firstName: "Marie")
+        traits.set(lastName: "Avgeropoulos")
+        traits.set(email: "marie.avgeropoulos@example.com")
+        traits.set(gender: .female)
+        traits.set(age: 30)
+        traits.set(phoneNumber: "555-555-5555")
+        traits.set(tags: ["actress", "model"])
+        
+        Rover.identify(traits: traits)
+    }
+    
+    func testIdentify() {
+        let customer = Rover.customer
+
+        // Can't test for nil because its impossible to reset NSUserDefaults with the
+        // current implementation.
+        // http://stackoverflow.com/questions/19084633/shouldnt-nsuserdefault-be-clean-slate-for-unit-tests
+        
+//        XCTAssertNil(customer.identifier)
+//        XCTAssertNil(customer.firstName)
+//        XCTAssertNil(customer.lastName)
+//        XCTAssertNil(customer.email)
+//        XCTAssertNil(customer.gender)
+//        XCTAssertNil(customer.age)
+//        XCTAssertNil(customer.phone)
+//        XCTAssertNil(customer.tags)
+        
+        identifyAsMarie()
+        
+        XCTAssertEqual(customer.identifier, "marieavgeropoulos")
+        XCTAssertEqual(customer.firstName, "Marie")
+        XCTAssertEqual(customer.lastName, "Avgeropoulos")
+        XCTAssertEqual(customer.gender, Traits.Gender.female.rawValue)
+        XCTAssertEqual(customer.age, 30)
+        XCTAssertEqual(customer.email, "marie.avgeropoulos@example.com")
+        XCTAssertEqual(customer.phone, "555-555-5555")
+        XCTAssertEqual(customer.tags!, ["actress", "model"])
+
+        var traits = Traits()
+        traits.add(tag: "musician")
+        traits.remove(tag: "actress")
+        
+        Rover.identify(traits: traits)
+        XCTAssertEqual(customer.tags!, ["model", "musician"])
+        
+        traits = Traits()
+        traits.set(customValue: "bar", forKey: "foo")
+        
+        Rover.identify(traits: traits)
+        XCTAssertEqual(customer.traits["foo"] as? String, "bar")
+    }
+    
+    func testClearCustomer() {
+        identifyAsMarie()
+        
+        Rover.clearCustomer()
+        
+        let customer = Rover.customer
+        
+        XCTAssertNil(customer.identifier)
+        XCTAssertNil(customer.firstName)
+        XCTAssertNil(customer.lastName)
+        XCTAssertNil(customer.email)
+        XCTAssertNil(customer.gender)
+        XCTAssertNil(customer.age)
+        XCTAssertNil(customer.phone)
+        XCTAssertNil(customer.tags)
+    }
+}

--- a/RoverTests/TraitsTests.swift
+++ b/RoverTests/TraitsTests.swift
@@ -98,6 +98,9 @@ class TraitsTests: XCTestCase {
         XCTAssertEqual(traits.valueMap.count, 2)
         XCTAssertEqual(traits.customValues?.count, 1)
         XCTAssertEqual(traits.customValues?["foo"] as? String, "bar")
+        
+        traits.removeCustomValue(forKey: "foo")
+        XCTAssert(traits.customValues?["foo"] is NSNull)
     }
     
     func testInitializeByDictionary() {

--- a/RoverTests/TraitsTests.swift
+++ b/RoverTests/TraitsTests.swift
@@ -1,0 +1,137 @@
+//
+//  TraitsTests.swift
+//  RoverTests
+//
+//  Created by Sean Rucker on 2016-12-05.
+//  Copyright © 2016 Sean Rucker. All rights reserved.
+//
+
+import XCTest
+@testable import Rover
+
+class TraitsTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testValueMap() {
+        var traits = Traits()
+        traits.set(identifier: "marieavgeropoulos")
+        traits.set(firstName: "Marie")
+        traits.set(lastName: "Avgeropoulos")
+        traits.set(email: "marie.avgeropoulos@example.com")
+        traits.set(gender: .female)
+        traits.set(age: 30)
+        traits.set(phoneNumber: "555-555-5555")
+        traits.set(tags: ["actress", "model", "musician"])
+        
+        XCTAssertEqual(traits.identifier as? String, "marieavgeropoulos")
+        XCTAssertEqual(traits.firstName as? String, "Marie")
+        XCTAssertEqual(traits.lastName as? String, "Avgeropoulos")
+        XCTAssertEqual(traits.gender as? String, Traits.Gender.female.rawValue)
+        XCTAssertEqual(traits.age as? Int, 30)
+        XCTAssertEqual(traits.email as? String, "marie.avgeropoulos@example.com")
+        XCTAssertEqual(traits.phoneNumber as? String, "555-555-5555")
+        XCTAssertEqual(traits.tags!, ["actress", "model", "musician"])
+    }
+    
+    func testAddRemoveTags() {
+        var traits = Traits()
+        traits.add(tag: "actress")
+        XCTAssertEqual(traits.tagsToAdd!, ["actress"])
+        
+        traits.add(tag: "model")
+        XCTAssertEqual(traits.tagsToAdd!, ["actress", "model"])
+        
+        traits.remove(tag: "musician")
+        XCTAssertEqual(traits.tagsToRemove!, ["musician"])
+    }
+    
+    func testNullValues() {
+        var traits = Traits()
+
+        traits.removeIdentifier()
+        traits.removeFirstName()
+        traits.removeLastName()
+        traits.removeEmail()
+        traits.removeGender()
+        traits.removeAge()
+        traits.removePhoneNumber()
+        
+        XCTAssert(traits.identifier is NSNull)
+        XCTAssert(traits.firstName is NSNull)
+        XCTAssert(traits.lastName is NSNull)
+        XCTAssert(traits.email is NSNull)
+        XCTAssert(traits.gender is NSNull)
+        XCTAssert(traits.age is NSNull)
+        XCTAssert(traits.phoneNumber is NSNull)
+    }
+    
+    func testNilValues() {
+        let traits = Traits()
+
+        XCTAssertNil(traits.identifier)
+        XCTAssertNil(traits.firstName)
+        XCTAssertNil(traits.lastName)
+        XCTAssertNil(traits.gender)
+        XCTAssertNil(traits.age)
+        XCTAssertNil(traits.email)
+        XCTAssertNil(traits.phoneNumber)
+    }
+    
+    func testCustomValues() {
+        var traits = Traits()
+        traits.set(customValue: "bar", forKey: "foo")
+        
+        XCTAssertEqual(traits.valueMap["foo"] as? String, "bar")
+        XCTAssertEqual(traits.valueMap.count, 1)
+        
+        traits.set(identifier: "marieavgeropoulos")
+        
+        XCTAssertEqual(traits.valueMap.count, 2)
+        XCTAssertEqual(traits.customValues?.count, 1)
+        XCTAssertEqual(traits.customValues?["foo"] as? String, "bar")
+    }
+    
+    func testInitializeByDictionary() {
+        let traits: Traits = [
+            Traits.identifierKey: "marieavgeropoulos",
+            Traits.tagsKey: ["actress"],
+            "foo": "bar"
+        ]
+        
+        XCTAssertEqual(traits.valueMap.count, 3)
+        XCTAssertEqual(traits.identifier as? String, "marieavgeropoulos")
+        XCTAssertEqual(traits.customValues?.count, 1)
+        XCTAssertEqual(traits.customValues?["foo"] as? String, "bar")
+    }
+    
+    func testInvalidDictionary() {
+        let traits: Traits = [
+            Traits.identifierKey: 80000516109,
+            Traits.firstNameKey: 999,
+            Traits.lastNameKey: 999,
+            Traits.emailKey: 999,
+            Traits.genderKey: "unidentified",
+            Traits.ageKey: "1",
+            Traits.phoneNumberKey: 5555555555,
+            Traits.tagsKey: "empty"
+        ]
+        
+        XCTAssertNil(traits.identifier)
+        XCTAssertNil(traits.firstName)
+        XCTAssertNil(traits.lastName)
+        XCTAssertNil(traits.gender)
+        XCTAssertNil(traits.age)
+        XCTAssertNil(traits.email)
+        XCTAssertNil(traits.phoneNumber)
+        XCTAssertNil(traits.tags)
+    }
+}


### PR DESCRIPTION
Adds the ability to identify a customer through the new traits API which is a set of instructions on how to modify the customer. This approach sets up well for the Rover 2.0 architecture.

Additionally the `Rover.identify` method now dispatches a device update event so that customer updates are persisted immediately. 

Similarly a `Rover.clearCustomer` method was added for "signing out".