### PR TITLE
add support for remote urls that return a data uri image string

### DIFF
--- a/Rover/UIImageView+RVAsset.swift
+++ b/Rover/UIImageView+RVAsset.swift
@@ -43,7 +43,19 @@ extension UIImageView {
             
             guard let data = data else { return }
             
-            self.image = UIImage(data: data)
+            if let img = UIImage(data: data) {
+                self.image = img
+            } else {
+                // data uri image support
+                do {
+                    if let str = String(data:data, encoding: String.Encoding.utf8),
+                        let dataUrl = URL(string: str),
+                        let decodedData = try? Data(contentsOf: dataUrl),
+                        let img = UIImage(data: decodedData) {
+                        self.image = img
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
@seanrucker here's a stab at data uri support.
This is for our particular use-case where we pass Rover an image url like "barcode.com?id=5" and that returns a data uri string like this "data:image/png;base64,AAA"