### PR TITLE
Custom Keys

### DIFF
--- a/Rover/Block.swift
+++ b/Rover/Block.swift
@@ -87,6 +87,7 @@ open class Block: NSObject {
     open var backgroundScale: CGFloat = 1
     
     open var action: Action?
+    open var customKeys = [String: String]()
 }
 
 class TextBlock: Block {

--- a/Rover/Experience.swift
+++ b/Rover/Experience.swift
@@ -13,6 +13,7 @@ open class Experience : NSObject {
     open let screens: [Screen]
     open let homeScreenIdentifier: String
     open var version: String?
+    open var customKeys = [String: String]()
     
     var homeScreen: Screen? {
         return screens.filter { $0.identifier == self.homeScreenIdentifier }.first

--- a/Rover/Mappables.swift
+++ b/Rover/Mappables.swift
@@ -196,6 +196,11 @@ extension Experience : Mappable {
         
         let experience = Experience(screens: screens, homeScreenIdentifier: homeScreenId, identifier: identifier)
         experience.version = attributes["version-id"] as? String
+        
+        if let customKeys = JSON["custom-keys"] as? [String: String] {
+            experience.customKeys = customKeys
+        }
+        
         return experience
     }
 }
@@ -223,6 +228,10 @@ extension Screen : Mappable {
         screen.backgroundContentMode = ImageContentMode(rawValue: JSON["background-content-mode"] as? String ?? "") ?? screen.backgroundContentMode
         screen.backgroundScale = JSON["background-scale"] as? CGFloat ?? screen.backgroundScale
         
+        if let customKeys = JSON["custom-keys"] as? [String: String] {
+            screen.customKeys = customKeys
+        }
+        
         return screen
     }
 }
@@ -243,6 +252,10 @@ extension Row : Mappable {
         
         if let isAutoHeight = JSON["auto-height"] as? Bool , isAutoHeight {
             row.height = nil
+        }
+        
+        if let customKeys = JSON["custom-keys"] as? [String: String] {
+            row.customKeys = customKeys
         }
         
         return row
@@ -336,6 +349,12 @@ extension Block : Mappable {
         block.backgroundImage = Image.instance(JSON["background-image"] as? [String : AnyObject] ?? [:], included: nil)
         block.backgroundContentMode = ImageContentMode(rawValue: JSON["background-content-mode"] as? String ?? "") ?? block.backgroundContentMode
         block.backgroundScale = JSON["background-scale"] as? CGFloat ?? block.backgroundScale
+        
+        // Custom Keys
+        
+        if let customKeys = JSON["custom-keys"] as? [String: String] {
+            block.customKeys = customKeys
+        }
         
         return block
     }

--- a/Rover/Row.swift
+++ b/Rover/Row.swift
@@ -16,6 +16,8 @@ open class Row: NSObject {
     
     open let backgroundBlock = Block()
     
+    open var customKeys = [String: String]()
+    
     init(blocks: [Block]) {
         backgroundBlock.position = .Floating
         backgroundBlock.alignment = Alignment(horizontal: .Fill, vertical: .Fill)

--- a/Rover/Screen.swift
+++ b/Rover/Screen.swift
@@ -34,6 +34,7 @@ open class Screen: NSObject {
     open var backgroundImage: Image?
     open var backgroundContentMode: ImageContentMode = .Original
     open var backgroundScale: CGFloat = 1
+    open var customKeys = [String: String]()
     
     init(rows: [Row]) {
         self.rows = rows


### PR DESCRIPTION
Experiences, screens, rows and blocks can now have custom keys attached in the Experiences (browser) app. This PR parses that data from the JSON payload and sets them on the model objects to make them available to app developers.