### PR TITLE
Campaign tracking

### DIFF
--- a/Rover/Event.swift
+++ b/Rover/Event.swift
@@ -28,10 +28,10 @@ public enum Event {
     case didEnterGimbalPlace(id: String, date: Date)
     case didExitGimbalPlace(id: String, date: Date)
     
-    case didLaunchExperience(Experience, session: String, date: Date)
-    case didDismissExperience(Experience, session: String, date: Date)
-    case didViewScreen(Screen, experience: Experience, fromScreen: Screen?, fromBlock: Block?, session: String, date: Date)
-    case didPressBlock(Block, screen: Screen, experience: Experience, session: String, date: Date)
+    case didLaunchExperience(Experience, session: String, date: Date, campaignID: String?)
+    case didDismissExperience(Experience, session: String, date: Date, campaignID: String?)
+    case didViewScreen(Screen, experience: Experience, fromScreen: Screen?, fromBlock: Block?, session: String, date: Date, campaignID: String?)
+    case didPressBlock(Block, screen: Screen, experience: Experience, session: String, date: Date, campaignID: String?)
     
     var properties: [String: Any] {
         switch self {

--- a/Rover/ExperienceViewController.swift
+++ b/Rover/ExperienceViewController.swift
@@ -21,13 +21,16 @@ open class ExperienceViewController: ModalViewController {
     internal(set) static weak var superDelegate: ExperienceViewControllerDelegate?
     
     var experience: Experience?
+    var campaignID: String?
     var operationQueue = OperationQueue()
     
     let sessionID = NSUUID().uuidString
     
-    required public init(identifier: String, useCurrentVersion: Bool = false) {
+    required public init(identifier: String, useCurrentVersion: Bool = false, campaignID: String? = nil) {
         super.init(rootViewController: LoadingViewController())
         view.backgroundColor = UIColor.white
+        
+        self.campaignID = campaignID
         
         let request = useCurrentVersion ? Router.getCurrentExperience(identifier).urlRequest : Router.getExperience(identifier).urlRequest
         

--- a/Rover/Rover.swift
+++ b/Rover/Rover.swift
@@ -519,7 +519,7 @@ extension Rover /*: RVRGimbalPlaceManagerDelegate*/ {
 extension Rover: ExperienceViewControllerDelegate {
     func experienceViewControllerDidLaunch(_ viewController: ExperienceViewController) {
         guard let experience = viewController.experience else { return }
-        sendEvent(.didLaunchExperience(experience, session: viewController.sessionID, date: Date()))
+        sendEvent(.didLaunchExperience(experience, session: viewController.sessionID, date: Date(), campaignID: nil))
         
         for observer in observers {
             observer.experienceViewControllerDidLaunch?(viewController)
@@ -528,7 +528,7 @@ extension Rover: ExperienceViewControllerDelegate {
     
     func experienceViewControllerDidDismiss(_ viewController: ExperienceViewController) {
         guard let experience = viewController.experience else { return }
-        sendEvent(.didDismissExperience(experience, session: viewController.sessionID, date: Date()))
+        sendEvent(.didDismissExperience(experience, session: viewController.sessionID, date: Date(), campaignID: nil))
         
         for observer in observers {
             observer.experienceViewControllerDidDismiss?(viewController)
@@ -537,7 +537,7 @@ extension Rover: ExperienceViewControllerDelegate {
     
     func experienceViewController(_ viewController: ExperienceViewController, didViewScreen screen: Screen, referrerScreen: Screen?, referrerBlock: Block?) {
         guard let experience = viewController.experience else { return }
-        sendEvent(.didViewScreen(screen, experience: experience, fromScreen: referrerScreen, fromBlock: referrerBlock, session: viewController.sessionID, date: Date()))
+        sendEvent(.didViewScreen(screen, experience: experience, fromScreen: referrerScreen, fromBlock: referrerBlock, session: viewController.sessionID, date: Date(), campaignID: nil))
         
         for observer in observers {
             observer.experienceViewController?(viewController, didViewScreen: screen, referrerScreen: referrerScreen, referrerBlock: referrerBlock)
@@ -546,7 +546,7 @@ extension Rover: ExperienceViewControllerDelegate {
     
     func experienceViewController(_ viewController: ExperienceViewController, didPressBlock block: Block, screen: Screen) {
         guard let experience = viewController.experience else { return }
-        sendEvent(.didPressBlock(block, screen: screen, experience: experience, session: viewController.sessionID, date: Date()))
+        sendEvent(.didPressBlock(block, screen: screen, experience: experience, session: viewController.sessionID, date: Date(), campaignID: nil))
         
         for observer in observers {
             observer.experienceViewController?(viewController, didPressBlock: block, screen: screen)

--- a/Rover/Rover.swift
+++ b/Rover/Rover.swift
@@ -519,7 +519,7 @@ extension Rover /*: RVRGimbalPlaceManagerDelegate*/ {
 extension Rover: ExperienceViewControllerDelegate {
     func experienceViewControllerDidLaunch(_ viewController: ExperienceViewController) {
         guard let experience = viewController.experience else { return }
-        sendEvent(.didLaunchExperience(experience, session: viewController.sessionID, date: Date(), campaignID: nil))
+        sendEvent(.didLaunchExperience(experience, session: viewController.sessionID, date: Date(), campaignID: viewController.campaignID))
         
         for observer in observers {
             observer.experienceViewControllerDidLaunch?(viewController)
@@ -528,7 +528,7 @@ extension Rover: ExperienceViewControllerDelegate {
     
     func experienceViewControllerDidDismiss(_ viewController: ExperienceViewController) {
         guard let experience = viewController.experience else { return }
-        sendEvent(.didDismissExperience(experience, session: viewController.sessionID, date: Date(), campaignID: nil))
+        sendEvent(.didDismissExperience(experience, session: viewController.sessionID, date: Date(), campaignID: viewController.campaignID))
         
         for observer in observers {
             observer.experienceViewControllerDidDismiss?(viewController)
@@ -537,7 +537,7 @@ extension Rover: ExperienceViewControllerDelegate {
     
     func experienceViewController(_ viewController: ExperienceViewController, didViewScreen screen: Screen, referrerScreen: Screen?, referrerBlock: Block?) {
         guard let experience = viewController.experience else { return }
-        sendEvent(.didViewScreen(screen, experience: experience, fromScreen: referrerScreen, fromBlock: referrerBlock, session: viewController.sessionID, date: Date(), campaignID: nil))
+        sendEvent(.didViewScreen(screen, experience: experience, fromScreen: referrerScreen, fromBlock: referrerBlock, session: viewController.sessionID, date: Date(), campaignID: viewController.campaignID))
         
         for observer in observers {
             observer.experienceViewController?(viewController, didViewScreen: screen, referrerScreen: referrerScreen, referrerBlock: referrerBlock)
@@ -546,7 +546,7 @@ extension Rover: ExperienceViewControllerDelegate {
     
     func experienceViewController(_ viewController: ExperienceViewController, didPressBlock block: Block, screen: Screen) {
         guard let experience = viewController.experience else { return }
-        sendEvent(.didPressBlock(block, screen: screen, experience: experience, session: viewController.sessionID, date: Date(), campaignID: nil))
+        sendEvent(.didPressBlock(block, screen: screen, experience: experience, session: viewController.sessionID, date: Date(), campaignID: viewController.campaignID))
         
         for observer in observers {
             observer.experienceViewController?(viewController, didPressBlock: block, screen: screen)

--- a/Rover/Serializables.swift
+++ b/Rover/Serializables.swift
@@ -127,7 +127,7 @@ extension Event : Serializable {
                 "action": "exit",
                 "gimbal-place-id": gimbalPlaceId
             ]
-        case .didLaunchExperience(let experience, let session, let date):
+        case .didLaunchExperience(let experience, let session, let date, let campaignID):
             timestamp = date
             serializedAttributes = [
                 "object": "experience",
@@ -136,7 +136,11 @@ extension Event : Serializable {
                 "version-id": experience.version ?? NSNull() as Any,
                 "experience-session-id": session
             ]
-        case .didDismissExperience(let experience, let session, let date):
+            
+            if let campaignID = campaignID {
+                serializedAttributes["campaign-id"] = campaignID
+            }
+        case .didDismissExperience(let experience, let session, let date, let campaignID):
             timestamp = date
             serializedAttributes = [
                 "object": "experience",
@@ -145,7 +149,11 @@ extension Event : Serializable {
                 "version-id": experience.version ?? NSNull() as Any,
                 "experience-session-id": session
             ]
-        case .didViewScreen(let screen, let experience, let fromScreen, let fromBlock, let session, let date):
+            
+            if let campaignID = campaignID {
+                serializedAttributes["campaign-id"] = campaignID
+            }
+        case .didViewScreen(let screen, let experience, let fromScreen, let fromBlock, let session, let date, let campaignID):
             timestamp = date
             serializedAttributes = [
                 "object": "experience",
@@ -157,7 +165,11 @@ extension Event : Serializable {
                 "version-id": experience.version ?? NSNull() as Any,
                 "experience-session-id": session
             ]
-        case .didPressBlock(let block, let screen, let experience, let session, let date):
+            
+            if let campaignID = campaignID {
+                serializedAttributes["campaign-id"] = campaignID
+            }
+        case .didPressBlock(let block, let screen, let experience, let session, let date, let campaignID):
             timestamp = date
             serializedAttributes = [
                 "object": "experience",
@@ -169,6 +181,10 @@ extension Event : Serializable {
                 "version-id": experience.version ?? NSNull() as Any,
                 "experience-session-id": session
             ]
+            
+            if let campaignID = campaignID {
+                serializedAttributes["campaign-id"] = campaignID
+            }
         default:
             break
         }


### PR DESCRIPTION
Adds the ability to associate all experience events with a unique campaign ID for analytics purposes.