### PR TITLE
Required Swift Version

### DIFF
--- a/Rover.podspec
+++ b/Rover.podspec
@@ -1,12 +1,13 @@
 Pod::Spec.new do |s|
-  s.name         = "Rover"
-  s.version      = "1.10.1"
-  s.summary      = "iOS framework for the Rover platform"
-  s.homepage     = "https://www.rover.io"
-  s.license      = "Apache License, Version 2.0"
-  s.author       = { "Rover Labs Inc." => "support@rover.io" }
-  s.platform     = :ios, "8.4"
-  s.source       = { :git => "https://github.com/RoverPlatform/rover-ios.git", :tag => "v#{s.version}" }
-  s.source_files = "Rover"
-  s.frameworks   = "UIKit", "Foundation", "CoreLocation"
+  s.name          = "Rover"
+  s.version       = "1.10.1"
+  s.summary       = "iOS framework for the Rover platform"
+  s.homepage      = "https://www.rover.io"
+  s.license       = "Apache License, Version 2.0"
+  s.author        = { "Rover Labs Inc." => "support@rover.io" }
+  s.platform      = :ios, "8.4"
+  s.source        = { :git => "https://github.com/RoverPlatform/rover-ios.git", :tag => "v#{s.version}" }
+  s.source_files  = "Rover"
+  s.swift_version = "4.0"
+  s.frameworks    = "UIKit", "Foundation", "CoreLocation"
 end

--- a/Rover.podspec
+++ b/Rover.podspec
@@ -1,13 +1,14 @@
 Pod::Spec.new do |s|
-  s.name          = "Rover"
-  s.version       = "1.10.1"
-  s.summary       = "iOS framework for the Rover platform"
-  s.homepage      = "https://www.rover.io"
-  s.license       = "Apache License, Version 2.0"
-  s.author        = { "Rover Labs Inc." => "support@rover.io" }
-  s.platform      = :ios, "8.4"
-  s.source        = { :git => "https://github.com/RoverPlatform/rover-ios.git", :tag => "v#{s.version}" }
-  s.source_files  = "Rover"
-  s.swift_version = "4.0"
-  s.frameworks    = "UIKit", "Foundation", "CoreLocation"
+  s.name              = "Rover"
+  s.version           = "1.10.1"
+  s.summary           = "iOS framework for the Rover platform"
+  s.homepage          = "https://www.rover.io"
+  s.license           = "Apache License, Version 2.0"
+  s.author            = { "Rover Labs Inc." => "support@rover.io" }
+  s.platform          = :ios, "8.4"
+  s.source            = { :git => "https://github.com/RoverPlatform/rover-ios.git", :tag => "v#{s.version}" }
+  s.source_files      = "Rover"
+  s.swift_version     = "4.0"
+  s.cocoapods_version = ">= 1.4.0"
+  s.frameworks        = "UIKit", "Foundation", "CoreLocation"
 end


### PR DESCRIPTION
CocoaPods changed the way a pod author specifies the required Swift version from the `.swift-version` file to a required entry in the Podspec:

http://blog.cocoapods.org/CocoaPods-1.4.0/
(Swift Version DSL)

This PR adds the proper entries to the Podspec to require Swift 4.0 and a minimum version of Cocoapods 1.4.0 (prior to 1.4.0 the `swift_version` entry throws an error.