### PR TITLE
Analytics

### DIFF
--- a/Rover.xcodeproj/project.pbxproj
+++ b/Rover.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		4953DD5322399A9C00286C4B /* ScreenViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9DBEE32055964E00E5C77F /* ScreenViewLayout.swift */; };
 		4953DD5422399A9C00286C4B /* ScreenViewLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB00FDD92087E09F008D1A57 /* ScreenViewLayoutAttributes.swift */; };
 		49E752D4224017A4005CF00F /* Notification.Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E752D3224017A4005CF00F /* Notification.Name.swift */; };
+		DB637A872279EFC600F0E791 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB637A862279EFC600F0E791 /* Analytics.swift */; };
 		DB640B6D2245289800CFA795 /* ExperienceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB640B6C2245289800CFA795 /* ExperienceCache.swift */; };
 		DB640B6F22452AB000CFA795 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB640B6E22452AB000CFA795 /* ImageCache.swift */; };
 		DB640B712245343F00CFA795 /* SessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB640B702245343F00CFA795 /* SessionState.swift */; };
@@ -87,6 +88,7 @@
 		DB4831B920DC5D18003DBF1B /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		DB496E3D214854C50026DE6A /* HTTPResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResult.swift; sourceTree = "<group>"; };
 		DB496E3F214854CF0026DE6A /* HTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPError.swift; sourceTree = "<group>"; };
+		DB637A862279EFC600F0E791 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		DB640B6C2245289800CFA795 /* ExperienceCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceCache.swift; sourceTree = "<group>"; };
 		DB640B6E22452AB000CFA795 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		DB640B702245343F00CFA795 /* SessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionState.swift; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				DB6ADD7D20B3446D002F226C /* Services */,
 				DBF31B5A20E41C5A005D7C34 /* UI */,
 				DBFDF4B920AC95FD0031EF47 /* Vendor */,
+				DB637A862279EFC600F0E791 /* Analytics.swift */,
 				4953DD102239925B00286C4B /* Rover.swift */,
 				49952B452242B73A004C5521 /* Info.plist */,
 			);
@@ -524,6 +527,7 @@
 				4953DD3B22399A8500286C4B /* Insets.swift in Sources */,
 				4953DD3922399A8500286C4B /* Image.swift in Sources */,
 				4953DD3722399A8500286C4B /* Experience.swift in Sources */,
+				DB637A872279EFC600F0E791 /* Analytics.swift in Sources */,
 				4953DD4B22399A9700286C4B /* ButtonCell.swift in Sources */,
 				4953DD3E22399A8500286C4B /* Row.swift in Sources */,
 				4953DD3322399A8500286C4B /* Block.swift in Sources */,

--- a/Sources/Analytics.swift
+++ b/Sources/Analytics.swift
@@ -1,0 +1,158 @@
+//
+//  Analytics.swift
+//  Rover
+//
+//  Created by Sean Rucker on 2019-05-01.
+//  Copyright © 2019 Rover Labs Inc. All rights reserved.
+//
+
+import os.log
+import UIKit
+
+class Analytics {
+    static var shared = Analytics()
+    
+    private let session = URLSession(configuration: URLSessionConfiguration.default)
+    private var tokens: [NSObjectProtocol] = []
+    
+    func enable() {
+        guard tokens.isEmpty else {
+            return
+        }
+        
+        tokens = [
+            NotificationCenter.default.addObserver(forName: .RVExperiencePresented, object: nil, queue: nil) { [weak self] in
+                self?.trackEvent(name: "Experience Presented", userInfo: $0.userInfo)
+            },
+            NotificationCenter.default.addObserver(forName: .RVExperienceDismissed, object: nil, queue: nil) { [weak self] in
+                self?.trackEvent(name: "Experience Dismissed", userInfo: $0.userInfo)
+            },
+            NotificationCenter.default.addObserver(forName: .RVExperienceViewed, object: nil, queue: nil) { [weak self] in
+                self?.trackEvent(name: "Experience Viewed", userInfo: $0.userInfo)
+            },
+            NotificationCenter.default.addObserver(forName: .RVScreenPresented, object: nil, queue: nil) { [weak self] in
+                self?.trackEvent(name: "Screen Presented", userInfo: $0.userInfo)
+            },
+            NotificationCenter.default.addObserver(forName: .RVScreenDismissed, object: nil, queue: nil) { [weak self] in
+                self?.trackEvent(name: "Screen Dismissed", userInfo: $0.userInfo)
+            },
+            NotificationCenter.default.addObserver(forName: .RVScreenViewed, object: nil, queue: nil) { [weak self] in
+                self?.trackEvent(name: "Screen Viewed", userInfo: $0.userInfo)
+            },
+            NotificationCenter.default.addObserver(forName: .RVBlockTapped, object: nil, queue: nil) { [weak self] in
+                self?.trackEvent(name: "Block Tapped", userInfo: $0.userInfo)
+            }
+        ]
+    }
+    
+    func disable() {
+        tokens.forEach(NotificationCenter.default.removeObserver)
+    }
+    
+    deinit {
+        disable()
+    }
+    
+    private func trackEvent(name: String, userInfo: [AnyHashable: Any]?) {
+        let rawValue: [String: Any] = {
+            guard let userInfo = userInfo else {
+                return [:]
+            }
+            
+            return userInfo.reduce(into: [:], { (result, element) in
+                if let key = element.key as? String {
+                    result[key] = element.value
+                }
+            })
+        }()
+        
+        let properties = Properties(rawValue: rawValue)
+        let event = Event(name: name, properties: properties)
+        let data: Data
+        do {
+            data = try JSONEncoder.default.encode(event)
+        } catch {
+            os_log("Failed to encode event: %@", log: .rover, type: .error, error.localizedDescription)
+            return
+        }
+        
+        let url = URL(string: "https://analytics.rover.io")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue(UIDevice.current.identifierForVendor?.uuidString, forHTTPHeaderField: "x-rover-account-token")
+        
+        session.uploadTask(with: request, from: data).resume()
+    }
+}
+
+fileprivate struct Event: Encodable {
+    let name: String
+    let properties: Properties
+    let timestamp = Date()
+    
+    enum CodingKeys: String, CodingKey {
+        case name = "event"
+        case properties
+        case timestamp
+    }
+}
+
+fileprivate struct Properties: Encodable, RawRepresentable {
+    let rawValue: [String: Any]
+    
+    struct DynamicCodingKey: CodingKey {
+        var stringValue: String
+        
+        init(stringValue: String) {
+            self.stringValue = stringValue
+        }
+        
+        var intValue: Int?
+        
+        init?(intValue: Int) {
+            fatalError()
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicCodingKey.self)
+        try rawValue.forEach { element in
+            let key = DynamicCodingKey(stringValue: element.key)
+            try container.encode(element.value, forKey: key)
+        }
+    }
+}
+
+fileprivate extension KeyedEncodingContainer {
+    mutating func encode(_ value: Any, forKey key: Key) throws {
+        switch value {
+        case let value as Int:
+            try encode(value, forKey: key)
+        case let value as Bool:
+            try encode(value, forKey: key)
+        case let value as String:
+            try encode(value, forKey: key)
+        case let value as Double:
+            try encode(value, forKey: key)
+        case let value as [Int]:
+            try encode(value, forKey: key)
+        case let value as [Bool]:
+            try encode(value, forKey: key)
+        case let value as [Double]:
+            try encode(value, forKey: key)
+        case let value as [String]:
+            try encode(value, forKey: key)
+        case let value as [String: Any]:
+            var container = nestedContainer(keyedBy: Key.self, forKey: key)
+            try value.forEach { element in
+                if let key = Key(stringValue: element.key) {
+                    try container.encode(element.value, forKey: key)
+                }
+            }
+        default:
+            let context = EncodingError.Context(codingPath: codingPath, debugDescription: "Unexpected value type. Expected one of Int, String, Double, Boolean, or an array thereof, or a dictionary of all of the above including arrays.")
+            throw EncodingError.invalidValue(value, context)
+        }
+    }
+}

--- a/Sources/Analytics.swift
+++ b/Sources/Analytics.swift
@@ -70,7 +70,9 @@ class Analytics {
         let event = Event(name: name, properties: properties)
         let data: Data
         do {
-            data = try JSONEncoder.default.encode(event)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .formatted(DateFormatter.rfc3339)
+            data = try encoder.encode(event)
         } catch {
             os_log("Failed to encode event: %@", log: .rover, type: .error, error.localizedDescription)
             return

--- a/Sources/Analytics.swift
+++ b/Sources/Analytics.swift
@@ -82,7 +82,7 @@ class Analytics {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "content-type")
-        request.setValue(UIDevice.current.identifierForVendor?.uuidString, forHTTPHeaderField: "x-rover-account-token")
+        request.setValue(Rover.accountToken, forHTTPHeaderField: "x-rover-account-token")
         
         session.uploadTask(with: request, from: data).resume()
     }
@@ -92,11 +92,13 @@ fileprivate struct Event: Encodable {
     let name: String
     let properties: Properties
     let timestamp = Date()
+    let anonymousID = UIDevice.current.identifierForVendor?.uuidString
     
     enum CodingKeys: String, CodingKey {
         case name = "event"
         case properties
         case timestamp
+        case anonymousID
     }
 }
 

--- a/Sources/UI/RoverViewController.swift
+++ b/Sources/UI/RoverViewController.swift
@@ -58,6 +58,8 @@ open class RoverViewController: UIViewController {
         self.campaignID = campaignID
         super.init(nibName: nil, bundle: nil)
         
+        Analytics.shared.enable()
+        
         configureView()
         layoutActivityIndicator()
         layoutCancelButton()


### PR DESCRIPTION
Send all Rover experience events to analytics service. This is an intentionally simple implementation with very little dependency/impact to the rest of the SDK.

Closes #436 