### PR TITLE
Example App Tweaks

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -15,52 +15,50 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        Rover.accountToken = "blank"
+        // Pass your account token from the Rover Settings app to the Rover SDK.
+        Rover.accountToken = "YOUR_SDK_TOKEN"
         return true
     }
     
-    // This AppDelegate method receives deep links.
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        // Your app will likely have its own bespoke routing system for handling links. For the purposes of demonstration, a simple boilerplate example of how to handle deep links follows.  See the documentation for greater details.
-        // 'rover-example-app' given here is set in Example/Example/Info.plist as a URL Scheme.
+        // This app delegate method is called when any app (your own included) calls the `open(_:options:completionHandler:)` method on `UIApplication` with a URL that matches one of the schemes setup in your `Info.plist` file. These custom URL schemes are commonly referred to as "deep links". The `rover-example-app` scheme used below is set in Example/Example/Info.plist as a URL Scheme. Your app will likely have its own bespoke routing system for handling "deep links". For the purposes of demonstration, a simple boilerplate example follows. See the documentation for greater details.
+        
         if url.scheme == "rover-example-app" && url.host == "presentExperience" {
-            // The following code demonstrates an simple example for parsing an arbitrarily selected URI scheme.
+            // Capture the ID of the Rover experience from the URL.
             let components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)
-            guard let experienceID = (components?.queryItems?.first { $0.name == "id" })?.value else {
+            guard let experienceID = components?.queryItems?.first(where: { $0.name == "id" })?.value else {
                 return false
             }
-            let campaignID = components?.queryItems?.first { $0.name == "campaignID" }?.value
             
-            let roverViewController = RoverViewController(experienceID: experienceID, campaignID: campaignID)
+            // Capture the (optional) campaign ID from the URL.
+            let campaignID = components?.queryItems?.first(where: { $0.name == "campaignID" })?.value
+            
+            // Instantiate a `RoverViewController` with the experience and (optional) campaign ID.
+            let viewController = RoverViewController(experienceID: experienceID, campaignID: campaignID)
             
             // Use our UIApplication.present() helper extension method to find the currently active view controller, and present RoverViewController on top.
-            app.present(
-                roverViewController,
-                animated: true
-            )
+            app.present(viewController, animated: true)
+            return true
         }
+        
         return false
     }
     
-    // This AppDelegate method receives receives universal links, amongst other things such as Handoff.
     func application(_ app: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        // Your app will likely have its own bespoke routing system for handling links. For the purposes of demonstration, a simple boilerplate example of how to handle universal links follows.  See the documentation for greater details.
+        // This app delegate method is called in response to the user opening a Universal Link, amongst other things such as Handoff. Before we continue, check `activityType` to see if this method was called in response to a Universal Link.
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb, let url = userActivity.webpageURL else {
             return false
         }
         
-        // 'example.rover.io' given here needs to be set in your App Links configuration and entitlements. See the documentation for further details.
+        // Check the URL to see if the domain matches the one assigned to your Rover account. the `example.rover.io` domain used below needs to be set in your App Links configuration and entitlements. See the documentation for further details.
         if url.host == "example.rover.io" {
             let roverViewController = RoverViewController(experienceURL: url)
             
             // Use our UIApplication.present() helper extension method to find the currently active view controller, and present RoverViewController on top.
-            app.present(
-                roverViewController,
-                animated: true
-            )
+            app.present(roverViewController, animated: true)
             return true
         }
+        
         return false
     }
 }


### PR DESCRIPTION
Cleaned up some of the comments to be more consistent stylistically with the RoverCampaigns example app.

Also added a missing `return true` statement in the deep link handling code.