### PR TITLE
Multiple Deep Link Examples

### DIFF
--- a/Example/Example/Info.plist
+++ b/Example/Example/Info.plist
@@ -41,7 +41,7 @@
 			<string>io.rover.Example</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>rover-example-app</string>
+				<string>example</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
While exploring the idea of a convenience initializer on the RoverViewController to remove some of the boilerplate, I found it was not adding a ton of value and actually hiding some of the implementation details that are useful to a developer's understanding of how to customize the implementation to their own app.

Instead, I opted to provide an additional deep link example, demonstrating the various ways a developer can map custom URLs to Rover experiences.