### PR TITLE
Swift 4.0 Support

### DIFF
--- a/Rover.podspec
+++ b/Rover.podspec
@@ -8,7 +8,6 @@ Pod::Spec.new do |s|
   s.platform          = :ios, "10.0"
   s.source            = { :git => "https://github.com/RoverPlatform/rover-ios.git", :tag => "v#{s.version}" }
   s.cocoapods_version = ">= 1.4.0"
-  s.swift_version     = "5.0"
   s.source_files      = "Sources/**/*.swift"
   s.frameworks        = "SafariServices", "WebKit"
 end

--- a/Sources/Models/Barcode.swift
+++ b/Sources/Models/Barcode.swift
@@ -83,8 +83,12 @@ extension Barcode {
         
         params["inputMessage"] = data
         
+        #if swift(>=4.2)
         let filter = CIFilter(name: filterName, parameters: params)!
-                
+        #else
+        let filter = CIFilter(name: filterName, withInputParameters: params)!
+        #endif
+        
         guard let outputImage = filter.outputImage else {
             os_log("Unable to render barcode - see logs emitted directly by CIFilter for details", log: .rover, type: .error)
             return nil

--- a/Sources/Services/SessionController.swift
+++ b/Sources/Services/SessionController.swift
@@ -19,9 +19,17 @@ class SessionController {
     private var observers: [NSObjectProtocol] = []
     
     private init() {
+        #if swift(>=4.2)
+        let didBecomeActiveNotification = UIApplication.didBecomeActiveNotification
+        let willResignActiveNotification = UIApplication.willResignActiveNotification
+        #else
+        let didBecomeActiveNotification = NSNotification.Name.UIApplicationDidBecomeActive
+        let willResignActiveNotification = NSNotification.Name.UIApplicationWillResignActive
+        #endif
+        
         observers = [
             NotificationCenter.default.addObserver(
-                forName: UIApplication.didBecomeActiveNotification,
+                forName: didBecomeActiveNotification,
                 object: nil,
                 queue: OperationQueue.main,
                 using: { _ in
@@ -31,7 +39,7 @@ class SessionController {
                 }
             ),
             NotificationCenter.default.addObserver(
-                forName: UIApplication.willResignActiveNotification,
+                forName: willResignActiveNotification,
                 object: nil,
                 queue: OperationQueue.main,
                 using: { _ in

--- a/Sources/UI/ExperienceViewController.swift
+++ b/Sources/UI/ExperienceViewController.swift
@@ -20,9 +20,15 @@ open class ExperienceViewController: UINavigationController {
     public let experience: Experience
     public let campaignID: String?
     
+    #if swift(>=4.2)
     override open var childForStatusBarStyle: UIViewController? {
         return self.topViewController
     }
+    #else
+    override open var childViewControllerForStatusBarStyle: UIViewController? {
+        return self.topViewController
+    }
+    #endif
     
     public init(experience: Experience, campaignID: String?) {
         self.experience = experience

--- a/Sources/UI/LoadingViewController.swift
+++ b/Sources/UI/LoadingViewController.swift
@@ -15,7 +15,11 @@ import UIKit
 /// also displays a cancel button. When the cancel button is tapped it dismisses the view controller.
 open class LoadingViewController: UIViewController {
     /// The activity indicator displayed in the center of the screen.
+    #if swift(>=4.2)
     public var activityIndicator = UIActivityIndicatorView(style: .whiteLarge)
+    #else
+    public var activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
+    #endif
     
     /// The cancel button displayed below the activity indicator after 3 seconds.
     public var cancelButton = UIButton(type: .custom)

--- a/Sources/UI/RoverViewController.swift
+++ b/Sources/UI/RoverViewController.swift
@@ -19,9 +19,15 @@ import UIKit
 /// Rover SDK comes with a default loading screen `LoadingViewController` which you can override and customize to suit
 /// your needs. You can also supply your own view controller.
 open class RoverViewController: UIViewController {
+    #if swift(>=4.2)
     override open var childForStatusBarStyle: UIViewController? {
         return self.children.first
     }
+    #else
+    override open var childViewControllerForStatusBarStyle: UIViewController? {
+        return self.childViewControllers.first
+    }
+    #endif
     
     private var campaignID: String?
     private var identifier: ExperienceStore.Identifier?
@@ -85,6 +91,7 @@ open class RoverViewController: UIViewController {
         }
     }
     
+    #if swift(>=4.2)
     private func setChildViewController(_ childViewController: UIViewController) {
         if let existingChildViewController = self.children.first {
             existingChildViewController.willMove(toParent: nil)
@@ -98,6 +105,21 @@ open class RoverViewController: UIViewController {
         view.addSubview(childViewController.view)
         childViewController.didMove(toParent: self)
     }
+    #else
+    private func setChildViewController(_ childViewController: UIViewController) {
+        if let existingChildViewController = self.childViewControllers.first {
+            existingChildViewController.willMove(toParentViewController: nil)
+            existingChildViewController.view.removeFromSuperview()
+            existingChildViewController.removeFromParentViewController()
+        }
+        
+        childViewController.willMove(toParentViewController: self)
+        addChildViewController(childViewController)
+        childViewController.view.frame = view.bounds
+        view.addSubview(childViewController.view)
+        childViewController.didMove(toParentViewController: self)
+    }
+    #endif
     
     private func present(error: Error?, shouldRetry: Bool) {
         let alertController: UIAlertController

--- a/Sources/UI/Views/BarcodeCell.swift
+++ b/Sources/UI/Views/BarcodeCell.swift
@@ -17,7 +17,13 @@ class BarcodeCell: BlockCell {
         // a sharp scale of the pixels.  While we could use .scaleToFit, .scaleToFill will avoid the barcode
         // leaving any unexpected gaps around the outside in case of lack of agreement.
         imageView.contentMode = .scaleToFill
+        
+        #if swift(>=4.2)
         imageView.layer.magnificationFilter = CALayerContentsFilter.nearest
+        #else
+        imageView.layer.magnificationFilter = kCAFilterNearest
+        #endif
+        
         return imageView
     }()
     


### PR DESCRIPTION
The SDK supported both Swift 4.2 and Swift 5.0 mode but did not support Swift 4.0 mode. Using conditional compilation we can achieve support for all three. 

In order for CocoaPods to support multiple versions we need to remove the `swift_version` entry from the podspec which will allow CocoaPods to use the same version as your project target.