### PR TITLE
Xcode 10.1 Support.

### DIFF
--- a/Rover.xcodeproj/project.pbxproj
+++ b/Rover.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		4953DD5222399A9C00286C4B /* ScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9DBEE02055964E00E5C77F /* ScreenViewController.swift */; };
 		4953DD5322399A9C00286C4B /* ScreenViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9DBEE32055964E00E5C77F /* ScreenViewLayout.swift */; };
 		4953DD5422399A9C00286C4B /* ScreenViewLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB00FDD92087E09F008D1A57 /* ScreenViewLayoutAttributes.swift */; };
+		49C04DB8229DB11100243504 /* ResultShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C04DB7229DB11100243504 /* ResultShim.swift */; };
 		DB637A872279EFC600F0E791 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB637A862279EFC600F0E791 /* Analytics.swift */; };
 		DB6BE8AE215D41F7000A1FDA /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6BE8AD215D41F7000A1FDA /* OSLog.swift */; };
 		DB8FF7102286064400BDE2DC /* ExperienceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8FF70F2286064400BDE2DC /* ExperienceStore.swift */; };
@@ -66,6 +67,7 @@
 		49005D0322776283009D62F9 /* UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplication.swift; sourceTree = "<group>"; };
 		4953DD102239925B00286C4B /* Rover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rover.swift; sourceTree = "<group>"; };
 		49952B452242B73A004C5521 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		49C04DB7229DB11100243504 /* ResultShim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultShim.swift; sourceTree = "<group>"; };
 		DB00FDD92087E09F008D1A57 /* ScreenViewLayoutAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenViewLayoutAttributes.swift; sourceTree = "<group>"; };
 		DB00FDDF208A4961008D1A57 /* BarcodeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeCell.swift; sourceTree = "<group>"; };
 		DB637A862279EFC600F0E791 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 				DB8FF70F2286064400BDE2DC /* ExperienceStore.swift */,
 				DB709C6B207EAEED00F96C2B /* ImageStore.swift */,
 				DB6ADD7E20B3449E002F226C /* SessionController.swift */,
+				49C04DB7229DB11100243504 /* ResultShim.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -423,6 +426,7 @@
 				4953DD5222399A9C00286C4B /* ScreenViewController.swift in Sources */,
 				4953DD3522399A8500286C4B /* ButtonBlock.swift in Sources */,
 				4953DD3022399A8500286C4B /* Background.swift in Sources */,
+				49C04DB8229DB11100243504 /* ResultShim.swift in Sources */,
 				DB6BE8AE215D41F7000A1FDA /* OSLog.swift in Sources */,
 				4953DD3C22399A8500286C4B /* Position.swift in Sources */,
 				DB8FF71222861B5800BDE2DC /* DateFormatter.swift in Sources */,

--- a/Sources/Services/ResultShim.swift
+++ b/Sources/Services/ResultShim.swift
@@ -1,0 +1,178 @@
+// This is a copy of Result.swift from upstream Swift.  Using the proceprocessor to include it when using the old version of Swift (namely, of its standard library, not the language version level)
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=5.0)
+#else
+/// A value that represents either a success or a failure, including an
+/// associated value in each case.
+//@_frozen
+public enum Result<Success, Failure: Error> {
+    /// A success, storing a `Success` value.
+    case success(Success)
+    
+    /// A failure, storing a `Failure` value.
+    case failure(Failure)
+    
+    /// Returns a new result, mapping any success value using the given
+    /// transformation.
+    ///
+    /// Use this method when you need to transform the value of a `Result`
+    /// instance when it represents a success. The following example transforms
+    /// the integer success value of a result into a string:
+    ///
+    ///     func getNextInteger() -> Result<Int, Error> { /* ... */ }
+    ///
+    ///     let integerResult = getNextInteger()
+    ///     // integerResult == .success(5)
+    ///     let stringResult = integerResult.map({ String($0) })
+    ///     // stringResult == .success("5")
+    ///
+    /// - Parameter transform: A closure that takes the success value of this
+    ///   instance.
+    /// - Returns: A `Result` instance with the result of evaluating `transform`
+    ///   as the new success value if this instance represents a success.
+    public func map<NewSuccess>(
+        _ transform: (Success) -> NewSuccess
+        ) -> Result<NewSuccess, Failure> {
+        switch self {
+        case let .success(success):
+            return .success(transform(success))
+        case let .failure(failure):
+            return .failure(failure)
+        }
+    }
+    
+    /// Returns a new result, mapping any failure value using the given
+    /// transformation.
+    ///
+    /// Use this method when you need to transform the value of a `Result`
+    /// instance when it represents a failure. The following example transforms
+    /// the error value of a result by wrapping it in a custom `Error` type:
+    ///
+    ///     struct DatedError: Error {
+    ///         var error: Error
+    ///         var date: Date
+    ///
+    ///         init(_ error: Error) {
+    ///             self.error = error
+    ///             self.date = Date()
+    ///         }
+    ///     }
+    ///
+    ///     let result: Result<Int, Error> = // ...
+    ///     // result == .failure(<error value>)
+    ///     let resultWithDatedError = result.mapError({ e in DatedError(e) })
+    ///     // result == .failure(DatedError(error: <error value>, date: <date>))
+    ///
+    /// - Parameter transform: A closure that takes the failure value of the
+    ///   instance.
+    /// - Returns: A `Result` instance with the result of evaluating `transform`
+    ///   as the new failure value if this instance represents a failure.
+    public func mapError<NewFailure>(
+        _ transform: (Failure) -> NewFailure
+        ) -> Result<Success, NewFailure> {
+        switch self {
+        case let .success(success):
+            return .success(success)
+        case let .failure(failure):
+            return .failure(transform(failure))
+        }
+    }
+    
+    /// Returns a new result, mapping any success value using the given
+    /// transformation and unwrapping the produced result.
+    ///
+    /// - Parameter transform: A closure that takes the success value of the
+    ///   instance.
+    /// - Returns: A `Result` instance with the result of evaluating `transform`
+    ///   as the new failure value if this instance represents a failure.
+    public func flatMap<NewSuccess>(
+        _ transform: (Success) -> Result<NewSuccess, Failure>
+        ) -> Result<NewSuccess, Failure> {
+        switch self {
+        case let .success(success):
+            return transform(success)
+        case let .failure(failure):
+            return .failure(failure)
+        }
+    }
+    
+    /// Returns a new result, mapping any failure value using the given
+    /// transformation and unwrapping the produced result.
+    ///
+    /// - Parameter transform: A closure that takes the failure value of the
+    ///   instance.
+    /// - Returns: A `Result` instance, either from the closure or the previous
+    ///   `.success`.
+    public func flatMapError<NewFailure>(
+        _ transform: (Failure) -> Result<Success, NewFailure>
+        ) -> Result<Success, NewFailure> {
+        switch self {
+        case let .success(success):
+            return .success(success)
+        case let .failure(failure):
+            return transform(failure)
+        }
+    }
+    
+    /// Returns the success value as a throwing expression.
+    ///
+    /// Use this method to retrieve the value of this result if it represents a
+    /// success, or to catch the value if it represents a failure.
+    ///
+    ///     let integerResult: Result<Int, Error> = .success(5)
+    ///     do {
+    ///         let value = try integerResult.get()
+    ///         print("The value is \(value).")
+    ///     } catch error {
+    ///         print("Error retrieving the value: \(error)")
+    ///     }
+    ///     // Prints "The value is 5."
+    ///
+    /// - Returns: The success value, if the instance represents a success.
+    /// - Throws: The failure value, if the instance represents a failure.
+    public func get() throws -> Success {
+        switch self {
+        case let .success(success):
+            return success
+        case let .failure(failure):
+            throw failure
+        }
+    }
+}
+
+// This isn't compatible with older Swift and we don't make use of it.
+
+//extension Result where Failure == Swift.Error {
+//    /// Creates a new result by evaluating a throwing closure, capturing the
+//    /// returned value as a success, or any thrown error as a failure.
+//    ///
+//    /// - Parameter body: A throwing closure to evaluate.
+//    @_transparent
+//    public init(catching body: () throws -> Success) {
+//        do {
+//            self = .success(try body())
+//        } catch {
+//            self = .failure(error)
+//        }
+//    }
+//}
+
+extension Result: Equatable where Success: Equatable, Failure: Equatable { }
+
+extension Result: Hashable where Success: Hashable, Failure: Hashable { }
+
+import Foundation
+
+#endif

--- a/Sources/Services/ResultShim.swift
+++ b/Sources/Services/ResultShim.swift
@@ -1,4 +1,4 @@
-// This is a copy of Result.swift from upstream Swift.  Using the proceprocessor to include it when using the old version of Swift (namely, of its standard library, not the language version level)
+// This is a copy of Result.swift from upstream Swift.  Using the proceprocessor to include it when using the old version of Swift (namely, of its standard library, not the language version level), plus a few tweaks to make it internal scope and remove an unneeded feature not supported with the older Swift stdlib.
 
 //===----------------------------------------------------------------------===//
 //
@@ -17,7 +17,7 @@
 /// A value that represents either a success or a failure, including an
 /// associated value in each case.
 //@_frozen
-public enum Result<Success, Failure: Error> {
+enum Result<Success, Failure: Error> {
     /// A success, storing a `Success` value.
     case success(Success)
     
@@ -42,7 +42,7 @@ public enum Result<Success, Failure: Error> {
     ///   instance.
     /// - Returns: A `Result` instance with the result of evaluating `transform`
     ///   as the new success value if this instance represents a success.
-    public func map<NewSuccess>(
+    func map<NewSuccess>(
         _ transform: (Success) -> NewSuccess
         ) -> Result<NewSuccess, Failure> {
         switch self {
@@ -79,7 +79,7 @@ public enum Result<Success, Failure: Error> {
     ///   instance.
     /// - Returns: A `Result` instance with the result of evaluating `transform`
     ///   as the new failure value if this instance represents a failure.
-    public func mapError<NewFailure>(
+    func mapError<NewFailure>(
         _ transform: (Failure) -> NewFailure
         ) -> Result<Success, NewFailure> {
         switch self {
@@ -97,7 +97,7 @@ public enum Result<Success, Failure: Error> {
     ///   instance.
     /// - Returns: A `Result` instance with the result of evaluating `transform`
     ///   as the new failure value if this instance represents a failure.
-    public func flatMap<NewSuccess>(
+    func flatMap<NewSuccess>(
         _ transform: (Success) -> Result<NewSuccess, Failure>
         ) -> Result<NewSuccess, Failure> {
         switch self {
@@ -115,7 +115,7 @@ public enum Result<Success, Failure: Error> {
     ///   instance.
     /// - Returns: A `Result` instance, either from the closure or the previous
     ///   `.success`.
-    public func flatMapError<NewFailure>(
+    func flatMapError<NewFailure>(
         _ transform: (Failure) -> Result<Success, NewFailure>
         ) -> Result<Success, NewFailure> {
         switch self {
@@ -142,7 +142,7 @@ public enum Result<Success, Failure: Error> {
     ///
     /// - Returns: The success value, if the instance represents a success.
     /// - Throws: The failure value, if the instance represents a failure.
-    public func get() throws -> Success {
+    func get() throws -> Success {
         switch self {
         case let .success(success):
             return success


### PR DESCRIPTION
Xcode moved to Swift 5, which is not ABI compatible with the 4.2 compiler that shipped with Xcode 10.1.

This means that 10.2 is not ABI compatible with 10.1, despite what the version number would suggest.

To support customers who are held back on the older ABI (and thus, Xcode 10.1) we need to build not only with the Swift 4.0 language level but also with the older stdlib.

As discussed, brought Result.swift over from Swift 5.x stdlib and use it for when building with Swift compilers (not language level, however) older than 5.x.