### PR TITLE
Allow for custom behaviour on Button Blocks

### DIFF
--- a/Sources/Models/BlockTapBehavior.swift
+++ b/Sources/Models/BlockTapBehavior.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum BlockTapBehavior {
+public enum BlockTapBehavior: Equatable {
     case goToScreen(screenID: String)
     case none
     case openURL(url: URL, dismiss: Bool)

--- a/Sources/UI/ScreenViewController.swift
+++ b/Sources/UI/ScreenViewController.swift
@@ -398,10 +398,6 @@ open class ScreenViewController: UICollectionViewController, UICollectionViewDat
     
     // MARK: UICollectionViewDelegate
     
-    override open func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        return true
-    }
-    
     override open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         defer {
             collectionView.deselectItem(at: indexPath, animated: true)

--- a/Sources/UI/ScreenViewController.swift
+++ b/Sources/UI/ScreenViewController.swift
@@ -399,14 +399,7 @@ open class ScreenViewController: UICollectionViewController, UICollectionViewDat
     // MARK: UICollectionViewDelegate
     
     override open func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        // No-op if the block does not have any meaningful behavior to avoid every rectangle, line, image etc. tracking events
-        
-        switch screen.rows[indexPath.section].blocks[indexPath.row].tapBehavior {
-        case .none:
-            return false
-        default:
-            return true
-        }
+        return true
     }
     
     override open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/Sources/UI/ScreenViewController.swift
+++ b/Sources/UI/ScreenViewController.swift
@@ -398,6 +398,13 @@ open class ScreenViewController: UICollectionViewController, UICollectionViewDat
     
     // MARK: UICollectionViewDelegate
     
+    override open func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        let row = screen.rows[indexPath.section]
+        let block = row.blocks[indexPath.row]
+        
+        return block is ButtonBlock || block.tapBehavior != BlockTapBehavior.none
+    }
+    
     override open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         defer {
             collectionView.deselectItem(at: indexPath, animated: true)


### PR DESCRIPTION
Requirement:

* Allow for custom integration Block Tapped handlers by customers where they are not able to use a deep link as the target.

Currently, the SDK only emits Block Tapped events if the block has an Action other than None assigned.  Indeed, we only mark those blocks that have an Action set as Clickable/Selectable to the Android & iOS UI frameworks.  Setting all the blocks as clickable (so as to allow us to pick up the click events and then dispatch our Block Tapped events), however, is no solution because it defeats the purpose of Views being set clickable, thus breaking a11y (screenreader and the like) and potentially other functionality.

In the future, we may consider adding a "Custom" action type that must be selected instead of None in order to receive the events.  In the meantime, we will instead assume that Buttons are always meant to be clickable, and only mark other Block types as clickable if they have a non-None action type set.