### PR TITLE
guard logic for double voting did not work correctly because state mapping for UI was happening upstream.

### DIFF
--- a/Sources/Services/PollsVotingService.swift
+++ b/Sources/Services/PollsVotingService.swift
@@ -30,12 +30,9 @@ class PollsVotingService {
 
     /// Cast a vote on the poll.  Naturally may only be done once.  Synchronous, fire-and-forget, and best-effort. Any subscribers will be instantly notified (if possible) of the update.
     func castVote(pollID: String, givenOptionIds optionIds: [String], optionId: String) {
-        switch self.localStatusForPoll(pollID: pollID, givenOptionIds: optionIds) {
-        case .answered:
+        if let _ = self.localStateForPoll(pollID: pollID, givenCurrentOptionIds: optionIds).userVotedForOptionId {
             os_log("Can't vote twice.", log: .rover, type: .fault)
             return
-        default:
-            break;
         }
         
         dispatchCastVoteRequest(pollID: pollID, optionId: optionId)


### PR DESCRIPTION
Logic designed to present the Waiting for Answer state in the UI if local results weren't yet available was erroneously being used for interlocking votes.  So votes were always passed through.

Resolves #486 (independent of the design issue of what to show when results aren't available after voting).

