### PR TITLE
Hotfix v3.5.3: Ergonomics for handling Poll Answered events

### DIFF
--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -147,5 +147,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let block = notification.userInfo?[ScreenViewController.blockUserInfoKey] as! Block
             os_log("Block Tapped: \"%@\"", block.name)
         }
+        
+        NotificationCenter.default.addObserver(forName: ScreenViewController.pollAnsweredNotification, object: nil, queue:nil) { notification in
+            let experience = notification.userInfo?[ExperienceViewController.experienceUserInfoKey] as! Experience
+            let campaignID = notification.userInfo?[ExperienceViewController.campaignIDUserInfoKey] as? String
+            let screen = notification.userInfo?[ScreenViewController.screenUserInfoKey] as! Screen
+            let block = notification.userInfo?[ScreenViewController.blockUserInfoKey] as! PollBlock
+            let option = notification.userInfo?[ScreenViewController.optionUserInfoKey] as! PollOption
+            
+            os_log(
+                "Poll Answered: \"%@\" (campaignID=%@,experienceID=%@,screenID=%@,pollID=%@) answered with option \"%@\" (optionID=%@)",
+                block.poll.question.rawValue,
+                campaignID ?? "none",
+                experience.id,
+                screen.id,
+                block.pollID(containedBy: experience.id),
+                option.text.rawValue,
+                option.id
+            )
+        }
     }
 }

--- a/Sources/Models/PollBlock.swift
+++ b/Sources/Models/PollBlock.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol PollBlock {
+public protocol PollBlock: Block {
     var poll: Poll { get }
     
     var id: String { get }
@@ -17,6 +17,8 @@ public protocol PollBlock {
 }
 
 public protocol Poll {
+    var question: Text { get }
+    
     var optionIDs: [String] { get }
     
     var pollOptions: [PollOption] { get }


### PR DESCRIPTION
In order to (easily) get:

* block name
* any of the poll fields

in a Poll Answered receiver without some pattern-matching/casts, there were two (obviously) missing protocol conformances that I've added in.

And in the same stroke, also added Poll Answered to the example notification receivers in the Example App's AppDelegate.