### PR TITLE
Sizing and truncation issues with Text (both Text blocks and Polls)

### DIFF
--- a/Rover.xcodeproj/project.pbxproj
+++ b/Rover.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		4953DD5422399A9C00286C4B /* ScreenViewLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB00FDD92087E09F008D1A57 /* ScreenViewLayoutAttributes.swift */; };
 		4974281A2304813C008F8D35 /* ScreenViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497428192304813C008F8D35 /* ScreenViewLayout.swift */; };
 		4994669D22A19C99005ECD07 /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4994669C22A19C99005ECD07 /* URLRequest.swift */; };
+		4999A3B72433DC39007AC095 /* NSAttributedString+measurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4999A3B62433DC39007AC095 /* NSAttributedString+measurement.swift */; };
 		49C04DB8229DB11100243504 /* ResultShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C04DB7229DB11100243504 /* ResultShim.swift */; };
 		49C76DFF22E78C1F003E5CC7 /* UserDefaults+PollsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C76DFE22E78C1F003E5CC7 /* UserDefaults+PollsStorage.swift */; };
 		49ED505722FDE58B0027FAA5 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49ED505622FDE58B0027FAA5 /* Error.swift */; };
@@ -99,6 +100,7 @@
 		497428192304813C008F8D35 /* ScreenViewLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenViewLayout.swift; sourceTree = "<group>"; };
 		4994669C22A19C99005ECD07 /* URLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequest.swift; sourceTree = "<group>"; };
 		49952B452242B73A004C5521 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4999A3B62433DC39007AC095 /* NSAttributedString+measurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+measurement.swift"; sourceTree = "<group>"; };
 		49C04DB7229DB11100243504 /* ResultShim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultShim.swift; sourceTree = "<group>"; };
 		49C76DFE22E78C1F003E5CC7 /* UserDefaults+PollsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+PollsStorage.swift"; sourceTree = "<group>"; };
 		49ED505622FDE58B0027FAA5 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				492F7A5122E6640D00D1F653 /* UIView.swift */,
 				492F7A5322E6642900D1F653 /* UIImageView.swift */,
 				491EDCD722F38A99003FD25E /* LargestRemainder.swift */,
+				4999A3B62433DC39007AC095 /* NSAttributedString+measurement.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -520,6 +523,7 @@
 				4953DD3E22399A8500286C4B /* Row.swift in Sources */,
 				4953DD3322399A8500286C4B /* Block.swift in Sources */,
 				4914B3E622B83A4B00FA395E /* ImagePollBlock.swift in Sources */,
+				4999A3B72433DC39007AC095 /* NSAttributedString+measurement.swift in Sources */,
 				DB7B854223061448008D628E /* ImagePollCell.swift in Sources */,
 				DB7B853A23060FFB008D628E /* PollCell.swift in Sources */,
 				DB7B854A230633C1008D628E /* ImagePollOptionOverlay.swift in Sources */,

--- a/Sources/Models/Text.swift
+++ b/Sources/Models/Text.swift
@@ -53,12 +53,12 @@ public struct Text: Decodable {
 // MARK: Convenience Initializers
 
 extension Text {
-    func attributedText(forFormat format: NSAttributedString.DocumentType = .html) -> NSAttributedString? {
+    func attributedText(forFormat format: NSAttributedString.DocumentType) -> NSAttributedString? {
         guard let data = rawValue.data(using: String.Encoding.unicode) else {
             return nil
         }
         
-        let options = [NSAttributedString.DocumentReadingOptionKey.documentType: NSAttributedString.DocumentType.html]
+        let options = [NSAttributedString.DocumentReadingOptionKey.documentType: format]
         
         guard let attributedString = try? NSMutableAttributedString(data: data, options: options, documentAttributes: nil) else {
             return nil
@@ -67,7 +67,6 @@ extension Text {
         let range = NSRange(location: 0, length: attributedString.length)
         
         // Bold and italicize
-        
         attributedString.enumerateAttribute(NSAttributedString.Key.font, in: range, options: []) { value, range, _ in
             guard let value = value as? UIFont else {
                 return
@@ -92,8 +91,7 @@ extension Text {
         
         attributedString.addAttributes(attributes, range: range)
         
-        // Remove double newlines at end of string, as a workaround for an artifact that appears in some of the HTML structure in some experiences saved by older versions of the authoring tool.
-        
+        // Workaround to remove an unwanted trailing newline produced by a closing </p> tag being parsed by NSAttributeString's HTML parser.
         if format == .html {
             let string = attributedString.string
             if attributedString.length > 0 && string.suffix(1) == "\n" {

--- a/Sources/UI/ScreenViewLayout.swift
+++ b/Sources/UI/ScreenViewLayout.swift
@@ -127,28 +127,27 @@ class ScreenViewLayout: UICollectionViewLayout {
                     
                     intrinsicHeight = blockWidth / aspectRatio
                 case let block as ButtonBlock:
-                    guard let attributedText = block.text.attributedText() else {
+                    guard let attributedText = block.text.attributedText(forFormat: .html) else {
                         intrinsicHeight = nil
                         break
                     }
                     
                     let innerWidth = blockWidth - CGFloat(block.insets.left) - CGFloat(block.insets.right)
                     let size = CGSize(width: innerWidth, height: CGFloat.greatestFiniteMagnitude)
-                    let boundingRect = attributedText.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
-                    intrinsicHeight = boundingRect.height + CGFloat(block.insets.top) + CGFloat(block.insets.bottom)
+                    let measuredHeight = attributedText.measuredHeight(with: size)
+                    intrinsicHeight = measuredHeight + CGFloat(block.insets.top) + CGFloat(block.insets.bottom)
                 case let block as ImageBlock:
                     let aspectRatio = CGFloat(block.image.width) / CGFloat(block.image.height)
                     intrinsicHeight = blockWidth / aspectRatio
                 case let block as TextBlock:
-                    guard let attributedText = block.text.attributedText() else {
+                    guard let attributedText = block.text.attributedText(forFormat: .html) else {
                         intrinsicHeight = nil
                         break
                     }
-                    
                     let innerWidth = blockWidth - CGFloat(block.insets.left) - CGFloat(block.insets.right)
                     let size = CGSize(width: innerWidth, height: CGFloat.greatestFiniteMagnitude)
-                    let boundingRect = attributedText.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
-                    intrinsicHeight = boundingRect.height + CGFloat(block.insets.top) + CGFloat(block.insets.bottom)
+                    let measuredHeight = attributedText.measuredHeight(with: size)
+                    intrinsicHeight = measuredHeight + CGFloat(block.insets.top) + CGFloat(block.insets.bottom)
                 case let block as TextPollBlock:
                     intrinsicHeight = block.intrinsicHeight(blockWidth: blockWidth)
                 case let block as ImagePollBlock:

--- a/Sources/UI/Views/Extensions/NSAttributedString+measurement.swift
+++ b/Sources/UI/Views/Extensions/NSAttributedString+measurement.swift
@@ -1,0 +1,23 @@
+//
+//  NSAttributedString+measurement.swift
+//  Rover
+//
+//  Created by Andrew Clunis on 2020-03-31.
+//  Copyright © 2020 Rover Labs Inc. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension NSAttributedString {
+    func measuredHeight(with size: CGSize) -> CGFloat {
+        // Using NSAttributedString.boundingRect() does not handle certain characters and whitespace (basically, paragraph layout concerns) correctly/completely, and so often yields incorrect results.
+        let container = NSTextContainer(size: size)
+        container.lineFragmentPadding = 0
+        let layoutManager = NSLayoutManager()
+        layoutManager.addTextContainer(container)
+        let textStorage = NSTextStorage(attributedString: self)
+        textStorage.addLayoutManager(layoutManager)
+        return CGFloat(ceilf(Float(layoutManager.usedRect(for: container).size.height)))
+    }
+}

--- a/Sources/UI/Views/Polls/ImagePollCell.swift
+++ b/Sources/UI/Views/Polls/ImagePollCell.swift
@@ -101,7 +101,7 @@ extension ImagePollBlock {
         
         let questionAttributedText = self.imagePoll.question.attributedText(forFormat: .plain)
         
-        let questionHeight = questionAttributedText?.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).height ?? CGFloat(0)
+        let questionHeight = questionAttributedText?.measuredHeight(with: size) ?? CGFloat(0)
         
         let optionsHeightAndSpacing = self.imagePoll.options.tuples.map { (firstOption, secondOption) in
             let horizontalSpacing = CGFloat(secondOption.leftMargin)

--- a/Sources/UI/Views/Polls/TextPollCell.swift
+++ b/Sources/UI/Views/Polls/TextPollCell.swift
@@ -58,8 +58,8 @@ extension TextPollBlock {
         let size = CGSize(width: innerWidth, height: CGFloat.greatestFiniteMagnitude)
 
         let questionAttributedText = self.textPoll.question.attributedText(forFormat: .plain)
-
-        let questionHeight = questionAttributedText?.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).height ?? CGFloat(0)
+        
+        let questionHeight = questionAttributedText?.measuredHeight(with: size) ?? CGFloat(0)
 
         let borderHeight = CGFloat(textPoll.options.first?.border.width ?? 0) * 2
         

--- a/Sources/UI/Views/TextCell.swift
+++ b/Sources/UI/Views/TextCell.swift
@@ -31,6 +31,6 @@ class TextCell: BlockCell {
         }
         
         textView.isHidden = false
-        textView.attributedText = textBlock.text.attributedText()
+        textView.attributedText = textBlock.text.attributedText(forFormat: .html)
     }
 }


### PR DESCRIPTION
Changes:

* Fixed a bug where text for plain text items (namely for polls) was always being parsed as HTML;
* Switch from using NSAttributedText's `boundingRect()` method to using a full NSTextContainer and NSLayoutManager to measuring the height of text content. This is necessary because `boundingRect()` is only a basic tool and is not fully aware of larger text flow and layout concerns, such as paragraphs.

Resolves #523, #529.
