### PR TITLE
A11y fixes for Text and Actions

### DIFF
--- a/Sources/UI/Views/BlockCell.swift
+++ b/Sources/UI/Views/BlockCell.swift
@@ -47,6 +47,7 @@ class BlockCell: UICollectionViewCell {
         configureBorder()
         configureOpacity()
         configureContent()
+        configureA11yTraits()
     }
     
     func configureBackgroundColor() {
@@ -79,5 +80,31 @@ class BlockCell: UICollectionViewCell {
         }
         
         self.contentView.configureContent(content: content, withInsets: block.insets)
+    }
+    
+    func configureA11yTraits() {
+        guard let block = block, let content = content else {
+            return
+        }
+        
+        // we always use .link instead of .button, because buttons are meant for *actions* (doing an action, changing some state, or so on), rather than navigating between content.  All Rover Experience actions are about navigating around content, so we will always use .link.
+        switch block.tapBehavior {
+        case .goToScreen(_), .openURL(_, _), .presentWebsite(_):
+            content.accessibilityTraits.applyTrait(trait: .link, to: true)
+        default:
+            content.accessibilityTraits.applyTrait(trait: .link, to: false)
+        }
+    }
+}
+
+private extension UIAccessibilityTraits {
+    mutating func applyTrait(trait: UIAccessibilityTraits, to: Bool) {
+        if to {
+            // set the bit to 1.
+            self = UIAccessibilityTraits(rawValue: self.rawValue | trait.rawValue)
+        } else {
+            // set the bit to 0
+            self = UIAccessibilityTraits(rawValue: self.rawValue & ~trait.rawValue)
+        }
     }
 }

--- a/Sources/UI/Views/TextCell.swift
+++ b/Sources/UI/Views/TextCell.swift
@@ -13,6 +13,7 @@ class TextCell: BlockCell {
         let textView = UITextView()
         textView.backgroundColor = UIColor.clear
         textView.isEditable = false
+        textView.isUserInteractionEnabled = false
         textView.textContainer.lineFragmentPadding = 0
         textView.textContainerInset = UIEdgeInsets.zero
         return textView

--- a/Sources/UI/Views/TextCell.swift
+++ b/Sources/UI/Views/TextCell.swift
@@ -9,14 +9,12 @@
 import UIKit
 
 class TextCell: BlockCell {
-    let textView: UILabel = {
-        let textView = UILabel()
-        textView.numberOfLines = 0
+    let textView: UITextView = {
+        let textView = UITextView()
         textView.backgroundColor = UIColor.clear
-//        textView.isUserInteractionEnabled = false
-
-//        textView.textContainer.lineFragmentPadding = 0
-//        textView.textContainerInset = UIEdgeInsets.zero
+        textView.isEditable = false
+        textView.textContainer.lineFragmentPadding = 0
+        textView.textContainerInset = UIEdgeInsets.zero
         return textView
     }()
     

--- a/Sources/UI/Views/TextCell.swift
+++ b/Sources/UI/Views/TextCell.swift
@@ -9,12 +9,14 @@
 import UIKit
 
 class TextCell: BlockCell {
-    let textView: UITextView = {
-        let textView = UITextView()
+    let textView: UILabel = {
+        let textView = UILabel()
+        textView.numberOfLines = 0
         textView.backgroundColor = UIColor.clear
-        textView.isUserInteractionEnabled = false
-        textView.textContainer.lineFragmentPadding = 0
-        textView.textContainerInset = UIEdgeInsets.zero
+//        textView.isUserInteractionEnabled = false
+
+//        textView.textContainer.lineFragmentPadding = 0
+//        textView.textContainerInset = UIEdgeInsets.zero
         return textView
     }()
     
@@ -31,6 +33,6 @@ class TextCell: BlockCell {
         }
         
         textView.isHidden = false
-        textView.attributedText = textBlock.text.attributedText()
+        textView.attributedText = textBlock.text.attributedText(forFormat: .html)
     }
 }


### PR DESCRIPTION
* TextBlockCell now configures its UITextView with `isEditable = false` in addition to `textView.isUserInteractionEnabled = false`. The UITextView that believed it was editable, and responded as such to accessibility requests, causing Voice Over to exclaim "Text field; dimmed" after each text block.
* The `.link` UIAccessibilityTraits bit is now set to on for blocks that have any action applied. This was done instead of `.button` because `.link` is meant for navigation tasks, and `.button` is more meant for behavioural actions (send a message, buy something, otherwise change state), which our actions do not do.

Resolves #524 