### PR TITLE
Feature/conversion tracking

### DIFF
--- a/Rover.xcodeproj/project.pbxproj
+++ b/Rover.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		DB8FF71222861B5800BDE2DC /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8FF71122861B5800BDE2DC /* DateFormatter.swift */; };
 		DB8FF7142287423E00BDE2DC /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8FF7132287423E00BDE2DC /* LoadingViewController.swift */; };
 		DBF49DDD203DE00F00B54652 /* Rover.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBF49DD3203DE00F00B54652 /* Rover.framework */; };
+		F8AAA8042486E6D600FAF812 /* Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AAA8032486E6D600FAF812 /* Conversion.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -160,6 +161,7 @@
 		DBFB1A76209B8CC500E99F9F /* Text.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Text.swift; sourceTree = "<group>"; };
 		DBFB1A77209B8CC500E99F9F /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		DBFB1A78209B8CC500E99F9F /* ImageBlock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageBlock.swift; sourceTree = "<group>"; };
+		F8AAA8032486E6D600FAF812 /* Conversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conversion.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -337,6 +339,7 @@
 				4914B3E322B83A3F00FA395E /* PollBlock.swift */,
 				4914B3E522B83A4B00FA395E /* ImagePollBlock.swift */,
 				4914B3E922B9373900FA395E /* TextPollBlock.swift */,
+				F8AAA8032486E6D600FAF812 /* Conversion.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -516,6 +519,7 @@
 				DB8FF7102286064400BDE2DC /* ExperienceStore.swift in Sources */,
 				DB7B854623062AAE008D628E /* ImagePollOptionCaption.swift in Sources */,
 				492F7A5422E6642900D1F653 /* UIImageView.swift in Sources */,
+				F8AAA8042486E6D600FAF812 /* Conversion.swift in Sources */,
 				4953DD3B22399A8500286C4B /* Insets.swift in Sources */,
 				4953DD3922399A8500286C4B /* Image.swift in Sources */,
 				DB8FF7142287423E00BDE2DC /* LoadingViewController.swift in Sources */,

--- a/Sources/Models/BarcodeBlock.swift
+++ b/Sources/Models/BarcodeBlock.swift
@@ -18,8 +18,10 @@ public struct BarcodeBlock: Block {
     public var tapBehavior: BlockTapBehavior
     public var keys: [String: String]
     public var tags: [String]
+    public var conversion: Conversion?
+
     
-    public init(background: Background, barcode: Barcode, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String]) {
+    public init(background: Background, barcode: Barcode, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String], conversion: Conversion?) {
         self.background = background
         self.barcode = barcode
         self.border = border
@@ -31,5 +33,6 @@ public struct BarcodeBlock: Block {
         self.tapBehavior = tapBehavior
         self.keys = keys
         self.tags = tags
+        self.conversion = conversion
     }
 }

--- a/Sources/Models/Block.swift
+++ b/Sources/Models/Block.swift
@@ -17,4 +17,5 @@ public protocol Block: Decodable {
     var tapBehavior: BlockTapBehavior { get }
     var keys: [String: String] { get }
     var tags: [String] { get }
+    var conversion: Conversion? { get }
 }

--- a/Sources/Models/ButtonBlock.swift
+++ b/Sources/Models/ButtonBlock.swift
@@ -18,8 +18,10 @@ public struct ButtonBlock: Block {
     public var text: Text
     public var keys: [String: String]
     public var tags: [String]
+    public var conversion: Conversion?
+
     
-    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, text: Text, keys: [String: String], tags: [String]) {
+    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, text: Text, keys: [String: String], tags: [String], conversion: Conversion?) {
         self.background = background
         self.border = border
         self.id = id
@@ -31,5 +33,6 @@ public struct ButtonBlock: Block {
         self.text = text
         self.keys = keys
         self.tags = tags
+        self.conversion = conversion
     }
 }

--- a/Sources/Models/Conversion.swift
+++ b/Sources/Models/Conversion.swift
@@ -6,6 +6,16 @@
 //  Copyright © 2020 Rover Labs Inc. All rights reserved.
 //
 
+public struct Conversion: Decodable {
+    public var tag: String
+    public var expires: Duration
+    
+    
+    public init(tag: String, expires: Duration) {
+        self.tag = tag
+        self.expires = expires
+    }
+}
 
 public struct Duration: Decodable {
     public enum Unit: String, Decodable {
@@ -32,22 +42,10 @@ public struct Duration: Decodable {
         case .minutes:
             base = 60
         case .hours:
-            base =  60 * 60
+            base = 60 * 60
         case .days:
             base = 24 * 60 * 60
         }
         return TimeInterval(self.value * base)
-    }
-}
-
-
-public struct Conversion: Decodable {
-    public var tag: String
-    public var expires: Duration
-    
-    
-    public init(tag: String, expires: Duration) {
-        self.tag = tag
-        self.expires = expires
     }
 }

--- a/Sources/Models/Conversion.swift
+++ b/Sources/Models/Conversion.swift
@@ -1,0 +1,53 @@
+//
+//  Conversion.swift
+//  Rover
+//
+//  Created by Chris Recalis on 2020-06-02.
+//  Copyright © 2020 Rover Labs Inc. All rights reserved.
+//
+
+
+public struct Duration: Decodable {
+    public enum Unit: String, Decodable {
+        case seconds = "s"
+        case minutes = "m"
+        case hours = "h"
+        case days = "d"
+    }
+    
+    public var value: Int
+    public var unit: Unit
+    
+    
+    public init(value: Int, unit: Unit) {
+        self.value = value
+        self.unit = unit
+    }
+    
+    public var timeInterval: TimeInterval {
+        let base: Int
+        switch self.unit {
+        case .seconds:
+            base = 1
+        case .minutes:
+            base = 60
+        case .hours:
+            base =  60 * 60
+        case .days:
+            base = 24 * 60 * 60
+        }
+        return TimeInterval(self.value * base)
+    }
+}
+
+
+public struct Conversion: Decodable {
+    public var tag: String
+    public var expires: Duration
+    
+    
+    public init(tag: String, expires: Duration) {
+        self.tag = tag
+        self.expires = expires
+    }
+}

--- a/Sources/Models/ImageBlock.swift
+++ b/Sources/Models/ImageBlock.swift
@@ -18,8 +18,10 @@ public struct ImageBlock: Block {
     public var tapBehavior: BlockTapBehavior
     public var keys: [String: String]
     public var tags: [String]
+    public var conversion: Conversion?
+
     
-    public init(background: Background, border: Border, id: String, name: String, image: Image, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String]) {
+    public init(background: Background, border: Border, id: String, name: String, image: Image, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String], conversion: Conversion?) {
         self.background = background
         self.border = border
         self.id = id
@@ -31,5 +33,6 @@ public struct ImageBlock: Block {
         self.tapBehavior = tapBehavior
         self.keys = keys
         self.tags = tags
+        self.conversion = conversion
     }
 }

--- a/Sources/Models/ImagePollBlock.swift
+++ b/Sources/Models/ImagePollBlock.swift
@@ -60,8 +60,10 @@ public struct ImagePollBlock: Block {
     public var tapBehavior: BlockTapBehavior
     public var keys: [String: String]
     public var tags: [String]
+    public var conversion: Conversion?
+
     
-    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String], imagePoll: ImagePoll) {
+    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String], imagePoll: ImagePoll, conversion: Conversion?) {
         self.background = background
         self.border = border
         self.id = id
@@ -73,5 +75,6 @@ public struct ImagePollBlock: Block {
         self.keys = keys
         self.tags = tags
         self.imagePoll = imagePoll
+        self.conversion = conversion
     }
 }

--- a/Sources/Models/RectangleBlock.swift
+++ b/Sources/Models/RectangleBlock.swift
@@ -17,8 +17,10 @@ public struct RectangleBlock: Block {
     public var tapBehavior: BlockTapBehavior
     public var keys: [String: String]
     public var tags: [String]
+    public var conversion: Conversion?
+
     
-    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String]) {
+    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String], conversion: Conversion?) {
         self.background = background
         self.border = border
         self.id = id
@@ -29,5 +31,7 @@ public struct RectangleBlock: Block {
         self.tapBehavior = tapBehavior
         self.keys = keys
         self.tags = tags
+        self.conversion = conversion
+
     }
 }

--- a/Sources/Models/Screen.swift
+++ b/Sources/Models/Screen.swift
@@ -55,8 +55,9 @@ public struct Screen: Decodable {
     public var titleBar: TitleBar
     public var keys: [String: String]
     public var tags: [String]
+    public var conversion: Conversion?
     
-    public init(background: Background, id: String, name: String, isStretchyHeaderEnabled: Bool, rows: [Row], statusBar: StatusBar, titleBar: TitleBar, keys: [String: String], tags: [String]) {
+    public init(background: Background, id: String, name: String, isStretchyHeaderEnabled: Bool, rows: [Row], statusBar: StatusBar, titleBar: TitleBar, keys: [String: String], tags: [String], conversion: Conversion?) {
         self.background = background
         self.id = id
         self.name = name
@@ -66,5 +67,6 @@ public struct Screen: Decodable {
         self.titleBar = titleBar
         self.keys = keys
         self.tags = tags
+        self.conversion = conversion
     }
 }

--- a/Sources/Models/TextBlock.swift
+++ b/Sources/Models/TextBlock.swift
@@ -18,8 +18,10 @@ public struct TextBlock: Block {
     public var text: Text
     public var keys: [String: String]
     public var tags: [String]
+    public var conversion: Conversion?
+
     
-    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, text: Text, keys: [String: String], tags: [String]) {
+    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, text: Text, keys: [String: String], tags: [String], conversion: Conversion?) {
         self.background = background
         self.border = border
         self.id = id
@@ -31,5 +33,7 @@ public struct TextBlock: Block {
         self.text = text
         self.keys = keys
         self.tags = tags
+        self.conversion = conversion
+
     }
 }

--- a/Sources/Models/TextPollBlock.swift
+++ b/Sources/Models/TextPollBlock.swift
@@ -56,8 +56,10 @@ public struct TextPollBlock: Block {
     public var tapBehavior: BlockTapBehavior
     public var keys: [String: String]
     public var tags: [String]
+    public var conversion: Conversion?
+
     
-    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String], textPoll: TextPoll) {
+    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, keys: [String: String], tags: [String], textPoll: TextPoll, conversion: Conversion?) {
         self.background = background
         self.border = border
         self.id = id
@@ -69,5 +71,7 @@ public struct TextPollBlock: Block {
         self.keys = keys
         self.tags = tags
         self.textPoll = textPoll
+        self.conversion = conversion
+
     }
 }

--- a/Sources/Models/WebViewBlock.swift
+++ b/Sources/Models/WebViewBlock.swift
@@ -18,8 +18,10 @@ public struct WebViewBlock: Block {
     public var webView: WebView
     public var keys: [String: String]
     public var tags: [String]
+    public var conversion: Conversion?
+
     
-    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, webView: WebView, keys: [String: String], tags: [String]) {
+    public init(background: Background, border: Border, id: String, name: String, insets: Insets, opacity: Double, position: Position, tapBehavior: BlockTapBehavior, webView: WebView, keys: [String: String], tags: [String], conversion: Conversion?) {
         self.background = background
         self.border = border
         self.id = id
@@ -31,5 +33,7 @@ public struct WebViewBlock: Block {
         self.webView = webView
         self.keys = keys
         self.tags = tags
+        self.conversion = conversion
+
     }
 }


### PR DESCRIPTION
Adds new conversion tracking info on blocks & screens.

Blocks & Screens now have an additional optional `conversion` property attached to them.  A `Conversion` consist of the following:
```json
{
  "tag": "String",
  "expires": {
     "unit": "ENUM",
     "value": "Int"
  }
}
```
The new information added is to be used in conversion tracking by adding additional information to the user interacting with blocks & screens for some set duration of time. This info is used in the `rover-campaigns-ios` SDK to automatically tag a user under `userInfo`. Clients can then build segments around these tags as sort of an ad-hoc behavioural segment.