### PR TITLE
Prevent Problems with UIScreen.main.scale values of 0

### DIFF
--- a/Rover.xcodeproj/project.pbxproj
+++ b/Rover.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		4999A3B72433DC39007AC095 /* NSAttributedString+measurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4999A3B62433DC39007AC095 /* NSAttributedString+measurement.swift */; };
 		49C04DB8229DB11100243504 /* ResultShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C04DB7229DB11100243504 /* ResultShim.swift */; };
 		49C76DFF22E78C1F003E5CC7 /* UserDefaults+PollsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C76DFE22E78C1F003E5CC7 /* UserDefaults+PollsStorage.swift */; };
+		49DE0246254B6D0D00547C25 /* UIScreen+safeScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DE0245254B6D0D00547C25 /* UIScreen+safeScale.swift */; };
 		49ED505722FDE58B0027FAA5 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49ED505622FDE58B0027FAA5 /* Error.swift */; };
 		DB637A872279EFC600F0E791 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB637A862279EFC600F0E791 /* Analytics.swift */; };
 		DB6BE8AE215D41F7000A1FDA /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6BE8AD215D41F7000A1FDA /* OSLog.swift */; };
@@ -106,6 +107,7 @@
 		4999A3B62433DC39007AC095 /* NSAttributedString+measurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+measurement.swift"; sourceTree = "<group>"; };
 		49C04DB7229DB11100243504 /* ResultShim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultShim.swift; sourceTree = "<group>"; };
 		49C76DFE22E78C1F003E5CC7 /* UserDefaults+PollsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+PollsStorage.swift"; sourceTree = "<group>"; };
+		49DE0245254B6D0D00547C25 /* UIScreen+safeScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+safeScale.swift"; sourceTree = "<group>"; };
 		49ED505622FDE58B0027FAA5 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		DB00FDD92087E09F008D1A57 /* ScreenViewLayoutAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenViewLayoutAttributes.swift; sourceTree = "<group>"; };
 		DB00FDDF208A4961008D1A57 /* BarcodeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeCell.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				4994669C22A19C99005ECD07 /* URLRequest.swift */,
 				491A9FCA2305A7620069E038 /* URLSession+PollsRequests.swift */,
 				49C76DFE22E78C1F003E5CC7 /* UserDefaults+PollsStorage.swift */,
+				49DE0245254B6D0D00547C25 /* UIScreen+safeScale.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -537,6 +540,7 @@
 				DB7B854A230633C1008D628E /* ImagePollOptionOverlay.swift in Sources */,
 				4953DD3822399A8500286C4B /* Height.swift in Sources */,
 				DB7B853C23060FFB008D628E /* PollOptionFillBar.swift in Sources */,
+				49DE0246254B6D0D00547C25 /* UIScreen+safeScale.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Extensions/UIScreen+safeScale.swift
+++ b/Sources/Extensions/UIScreen+safeScale.swift
@@ -1,0 +1,17 @@
+//
+//  UIScreen+safeScale.swift
+//  Rover
+//
+//  Created by Andrew Clunis on 2020-10-29.
+//  Copyright © 2020 Rover Labs Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UIScreen {
+    var safeScale: CGFloat {
+        let value = self.scale
+        // in some cases, we have seen it occur that scale has returned 0. In that event, return a sane value.
+        return value == 0 ? 3.0 : value
+    }
+}

--- a/Sources/Services/ImageStore.swift
+++ b/Sources/Services/ImageStore.swift
@@ -231,16 +231,16 @@ extension ImageStore.Optimization {
     var queryItems: [URLQueryItem] {
         switch self {
         case .fill(let bounds):
-            let w = bounds.width * UIScreen.main.scale
-            let h = bounds.height * UIScreen.main.scale
+            let w = bounds.width * UIScreen.main.safeScale
+            let h = bounds.height * UIScreen.main.safeScale
             return [URLQueryItem(name: "fit", value: "min"), URLQueryItem(name: "w", value: w.paramValue), URLQueryItem(name: "h", value: h.paramValue)]
         case .fit(let bounds):
-            let w = bounds.width * UIScreen.main.scale
-            let h = bounds.height * UIScreen.main.scale
+            let w = bounds.width * UIScreen.main.safeScale
+            let h = bounds.height * UIScreen.main.safeScale
             return [URLQueryItem(name: "fit", value: "max"), URLQueryItem(name: "w", value: w.paramValue), URLQueryItem(name: "h", value: h.paramValue)]
         case let .stretch(bounds, originalSize):
-            let w = min(bounds.width * UIScreen.main.scale, originalSize.width)
-            let h = min(bounds.height * UIScreen.main.scale, originalSize.height)
+            let w = min(bounds.width * UIScreen.main.safeScale, originalSize.width)
+            let h = min(bounds.height * UIScreen.main.safeScale, originalSize.height)
             return [URLQueryItem(name: "w", value: w.paramValue), URLQueryItem(name: "h", value: h.paramValue)]
         case let .original(bounds, originalSize, originalScale):
             let width = min(bounds.width * originalScale, originalSize.width)
@@ -250,9 +250,9 @@ extension ImageStore.Optimization {
             let value = [x.paramValue, y.paramValue, width.paramValue, height.paramValue].joined(separator: ",")
             var queryItems = [URLQueryItem(name: "rect", value: value)]
             
-            if UIScreen.main.scale < originalScale {
-                let w = width / originalScale * UIScreen.main.scale
-                let h = height / originalScale * UIScreen.main.scale
+            if UIScreen.main.safeScale < originalScale {
+                let w = width / originalScale * UIScreen.main.safeScale
+                let h = height / originalScale * UIScreen.main.safeScale
                 queryItems.append(contentsOf: [URLQueryItem(name: "w", value: w.paramValue), URLQueryItem(name: "h", value: h.paramValue)])
             }
             
@@ -263,9 +263,9 @@ extension ImageStore.Optimization {
             let value = ["0", "0", width.paramValue, height.paramValue].joined(separator: ",")
             var queryItems = [URLQueryItem(name: "rect", value: value)]
             
-            if UIScreen.main.scale < originalScale {
-                let w = width / originalScale * UIScreen.main.scale
-                let h = height / originalScale * UIScreen.main.scale
+            if UIScreen.main.safeScale < originalScale {
+                let w = width / originalScale * UIScreen.main.safeScale
+                let h = height / originalScale * UIScreen.main.safeScale
                 queryItems.append(contentsOf: [URLQueryItem(name: "w", value: w.paramValue), URLQueryItem(name: "h", value: h.paramValue)])
             }
             
@@ -276,9 +276,9 @@ extension ImageStore.Optimization {
     var scale: CGFloat {
         switch self {
         case .original(_, _, let originalScale):
-            return UIScreen.main.scale < originalScale ? UIScreen.main.scale : originalScale
+            return UIScreen.main.safeScale < originalScale ? UIScreen.main.safeScale : originalScale
         case .tile(_, _, let originalScale):
-            return UIScreen.main.scale < originalScale ? UIScreen.main.scale : originalScale
+            return UIScreen.main.safeScale < originalScale ? UIScreen.main.safeScale : originalScale
         default:
             return 1
         }


### PR DESCRIPTION
Prevent a UIScreen.main.scale value of 0 from causing problems by returning a sane default (for most devices) of 3.0. This has been observed to occur in certain customer integrations.

We only use the value for specifying the density of the image we ask for Imgix to return, so as long as the value is not 0, then the correct layout for the image occurs (with the only potential issue of the resolution not perfectly matching the screen, which is almost certainly a non-issue).